### PR TITLE
Update sysfs settings

### DIFF
--- a/modules/lab-configuration.nix
+++ b/modules/lab-configuration.nix
@@ -32,6 +32,6 @@
   # The annoying thing is that Turbo Boost will unpredictably increase the clock speed
   # above its normal value based on stuff like how many cores are in use or temperature of the data center or ...
   boot.postBootCommands = ''
-    echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo`
+    echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo
   '';
 }

--- a/modules/lab-configuration.nix
+++ b/modules/lab-configuration.nix
@@ -33,5 +33,6 @@
   # above its normal value based on stuff like how many cores are in use or temperature of the data center or ...
   boot.postBootCommands = ''
     echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo
+    echo 2 > /sys/devices/cpu/rdpmc
   '';
 }


### PR DESCRIPTION
This PR updates the sysfs settings on lab servers:

- Fix a bug that prevented `no_turbo` from being enabled. Have to check whether this is the reason for the variation in SnabbCo/snabbswitch#744.
- Enable `RDPMC` instruction for all userspace processes. This is needed by the Snabb `lib.pmu` module. Linux kernel behavior recently changed to disallowing this instruction by default.