### PR TITLE
[WIP] self-upgrading snabblab built using Hydra

### DIFF
--- a/jobsets/snabblab.nix
+++ b/jobsets/snabblab.nix
@@ -1,0 +1,58 @@
+{ nixpkgsSrc ? <nixpkgs> }:
+
+with (import nixpkgsSrc {});
+
+let
+  mkChannel = { name, src, constituents ? [], meta ? {}, isNixOS ? true, ... }@args:
+    stdenv.mkDerivation ({
+      preferLocalBuild = true;
+      _hydraAggregate = true;
+
+      phases = [ "unpackPhase" "patchPhase" "installPhase" ];
+
+      patchPhase = stdenv.lib.optionalString isNixOS ''
+        touch .update-on-nixos-rebuild
+      '';
+
+      installPhase = ''
+        mkdir -p $out/{tarballs,nix-support}
+        tar cJf "$out/tarballs/nixexprs.tar.xz" \
+          --owner=0 --group=0 --mtime="1970-01-01 00:00:00 UTC" \
+          --transform='s!^\.!${name}!' .
+        echo "channel - $out/tarballs/nixexprs.tar.xz" > "$out/nix-support/hydra-build-products"
+        echo $constituents > "$out/nix-support/hydra-aggregate-constituents"
+        for i in $constituents; do
+          if [ -e "$i/nix-support/failed" ]; then
+            touch "$out/nix-support/failed"
+          fi
+        done
+      '';
+
+      meta = meta // {
+        isHydraChannel = true;
+      };
+    } // removeAttrs args [ "meta" ]);
+  mkChannelWithNixpkgs = { ... }@args:
+    let
+      src = stdenv.mkDerivation {
+        name = args.name + "-with-nixpkgs";
+        src = args.src;
+        phases = [ "unpackPhase" "installPhase" ];
+        installPhase = ''
+          cp -r --no-preserve=ownership "${nixpkgsSrc}/" nixpkgs
+          cp -r . $out
+        '';
+      };
+    in mkChannel (args // { inherit src; });
+   machines = import ../machines;
+in {
+  machines = stdenv.lib.genAttrs ["build1" "build2" "build3" "build4"]
+    (name: mkChannelWithNixpkgs {
+      name = "snabblab-machine-${name}";
+      constituents = [ machines.${name}.eval.config.system.build.toplevel ];
+      src = ./../.;
+    });
+
+  # build all our custom packages
+  inherit (import ./../pkgs {}) snabbpkgs;
+}

--- a/jobsets/snabblab.nix
+++ b/jobsets/snabblab.nix
@@ -56,7 +56,7 @@ let
     in mkChannel (args // { inherit src; });
    machines = import ../machines;
 in {
-  machines = stdenv.lib.genAttrs ["build1" "build2" "build3" "build4"]
+  machines = stdenv.lib.genAttrs ["build-1" "build-2" "build-3" "build-4"]
     (name: mkChannelWithNixpkgs {
       name = "snabblab-machine-${name}";
       constituents = [ machines.${name}.eval.config.system.build.toplevel ];

--- a/jobsets/snabblab.nix
+++ b/jobsets/snabblab.nix
@@ -1,8 +1,9 @@
-{ nixpkgsSrc ? <nixpkgs> }:
+{ nixpkgs ? <nixpkgs> }:
 
-with (import nixpkgsSrc {});
+with (import nixpkgs {});
 
 let
+  pkgs = (import nixpkgs {});
   mkChannel = { name, src, constituents ? [], meta ? {}, isNixOS ? true, ... }@args:
     stdenv.mkDerivation ({
       preferLocalBuild = true;
@@ -32,8 +33,8 @@ let
         isHydraChannel = true;
       };
     } // removeAttrs args [ "meta" ]);
-  nixpkgsShortRev = nixpkgsSrc.shortRev or "abcdefg";
-  nixpkgsVersion = "git-${toString nixpkgsSrc.revCount or 12345}.${nixpkgsShortRev}-snabblab";
+  nixpkgsShortRev = nixpkgs.shortRev or "abcdefg";
+  nixpkgsVersion = "-snabblab-git-${nixpkgsShortRev}";
   mkChannelWithNixpkgs = { ... }@args:
     let
       src = stdenv.mkDerivation {
@@ -41,7 +42,7 @@ let
         src = args.src;
         phases = [ "unpackPhase" "installPhase" ];
         installPhase = ''
-          cp -r --no-preserve=ownership "${nixpkgsSrc}/" nixpkgs
+          cp -r --no-preserve=ownership "${nixpkgs}/" nixpkgs
 
           # denote nixpkgs versioning
           chmod -R u+w nixpkgs
@@ -63,5 +64,5 @@ in {
     });
 
   # build all our custom packages
-  inherit (import ./../pkgs { pkgs = (import nixpkgsSrc {}); }) snabbpkgs;
+  inherit (import ./../pkgs { inherit pkgs; }) snabbpkgs;
 }

--- a/machines/default.nix
+++ b/machines/default.nix
@@ -1,9 +1,11 @@
+with (import <nixpkgs> {});
+
 let
   evalMachine = name:
     let
       modules = [
-        (import ./../machines/eiger.nix).${name}
-        (import ./../machines/eiger-production.nix).${name}
+        (import ../machines/eiger.nix).${name}
+        (import ../machines/eiger-production.nix).${name}
         { networking.hostName = name; }
       ];
     in {
@@ -12,5 +14,5 @@ let
         imports = modules;
       };
     };
-in
-  (import <nixpkgs> {}).stdenv.lib.genAttrs ["build1" "build2" "build3" "build4"] evalMachine
+  machines = ["build1" "build2" "build3" "build4"];
+in stdenv.lib.genAttrs machines evalMachine

--- a/machines/default.nix
+++ b/machines/default.nix
@@ -1,18 +1,12 @@
 with (import <nixpkgs> {});
 
 let
-  mapping = {
-   build1 = "build-1";
-   build2 = "build-2";
-   build3 = "build-3";
-   build4 = "build-4";
-  };
   evalMachine = name:
     let
       modules = [
         (import ../machines/eiger.nix).${name}
         (import ../machines/eiger-production.nix).${name}
-        { networking.hostName = mapping.${name}; }
+        { networking.hostName = name; }
       ];
     in {
       eval = import <nixpkgs/nixos/lib/eval-config.nix> { inherit modules; };
@@ -20,5 +14,5 @@ let
         imports = modules;
       };
     };
-  machines = ["build1" "build2" "build3" "build4"];
+  machines = ["build-1" "build-2" "build-3" "build-4"];
 in stdenv.lib.genAttrs machines evalMachine

--- a/machines/default.nix
+++ b/machines/default.nix
@@ -1,12 +1,18 @@
 with (import <nixpkgs> {});
 
 let
+  mapping = {
+   build1 = "build-1";
+   build2 = "build-2";
+   build3 = "build-3";
+   build4 = "build-4";
+  };
   evalMachine = name:
     let
       modules = [
         (import ../machines/eiger.nix).${name}
         (import ../machines/eiger-production.nix).${name}
-        { networking.hostName = name; }
+        { networking.hostName = mapping.${name}; }
       ];
     in {
       eval = import <nixpkgs/nixos/lib/eval-config.nix> { inherit modules; };

--- a/machines/default.nix
+++ b/machines/default.nix
@@ -4,6 +4,7 @@ let
       modules = [
         (import ./../machines/eiger.nix).${name}
         (import ./../machines/eiger-production.nix).${name}
+        { networking.hostName = name; }
       ];
     in {
       eval = import <nixpkgs/nixos/lib/eval-config.nix> { inherit modules; };

--- a/machines/default.nix
+++ b/machines/default.nix
@@ -1,0 +1,15 @@
+let
+  evalMachine = name:
+    let
+      modules = [
+        (import ./../machines/eiger.nix).${name}
+        (import ./../machines/eiger-production.nix).${name}
+      ];
+    in {
+      eval = import <nixpkgs/nixos/lib/eval-config.nix> { inherit modules; };
+      config = {
+        imports = modules;
+      };
+    };
+in
+  (import <nixpkgs> {}).stdenv.lib.genAttrs ["build1" "build2" "build3" "build4"] evalMachine

--- a/machines/eiger-hetzner.nix
+++ b/machines/eiger-hetzner.nix
@@ -17,8 +17,8 @@ let
 in {
   eiger  = mkMachine "136.243.111.220";
 
-  build1 = mkMachine "46.4.65.79";
-  build2 = mkMachine "78.46.84.196";
-  build3 = mkMachine "78.46.98.22";
-  build4 = mkMachine "46.4.108.125";
+  build-1 = mkMachine "46.4.65.79";
+  build-2 = mkMachine "78.46.84.196";
+  build-3 = mkMachine "78.46.98.22";
+  build-4 = mkMachine "46.4.108.125";
 }

--- a/machines/eiger-production.nix
+++ b/machines/eiger-production.nix
@@ -54,7 +54,7 @@ eiger = {
     })
   ];
 };
-build4 = {
+build-4 = {
   config = {
     networking = {
       defaultGateway = "46.4.108.97";
@@ -111,7 +111,7 @@ build4 = {
     })
   ];
 };
-build2 = {
+build-2 = {
   config = {
     networking = {
       defaultGateway = "78.46.84.193";
@@ -168,7 +168,7 @@ build2 = {
     })
   ];
 };
-build3 = {
+build-3 = {
   config = {
     networking = {
       defaultGateway = "78.46.98.1";
@@ -225,7 +225,7 @@ build3 = {
     })
   ];
 };
-build1 = {
+build-1 = {
   config = {
     networking = {
       defaultGateway = "46.4.65.65";

--- a/machines/eiger-production.nix
+++ b/machines/eiger-production.nix
@@ -1,0 +1,285 @@
+{
+eiger = {
+  config = {
+    networking = {
+      defaultGateway = "136.243.111.193";
+      interfaces.eth0 = { ipAddress = "136.243.111.220"; prefixLength = 26; };
+      localCommands = ''
+        ip -6 addr add '2a01:4f8:171:125b::/64' dev 'eth0' || true
+        ip -4 route change '136.243.111.192/26' via '136.243.111.193' dev 'eth0' || true
+        ip -6 route add default via 'fe80::1' dev eth0 || true
+      '';
+      nameservers = [
+        "213.133.98.98"
+        "213.133.99.99"
+        "213.133.100.100"
+        "2a01:4f8:0:a0a1::add:1010"
+        "2a01:4f8:0:a102::add:9999"
+        "2a01:4f8:0:a111::add:9898"
+      ];
+    };
+    services.udev.extraRules = ''
+      ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="90:1b:0e:8b:11:15", NAME="eth0"
+    '';
+    users.extraUsers.root.openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKQucTZ4iUufjr4+ViyvvuBufsMw7RbIkgoEgQxA+4e1 NixOps client key of eiger"
+    ];
+  };
+  imports = [
+    ({
+      swapDevices = [
+        { label = ""; }
+      ];
+      boot.loader.grub.devices = [
+        "/dev/sda"
+        "/dev/sdb"
+      ];
+      fileSystems = {
+        "/" = {
+          fsType = "ext4";
+          label = "root";
+        };
+      };
+    })
+    ({ config, lib, pkgs, ... }:
+    
+    {
+      imports = [ ];
+    
+      boot.initrd.availableKernelModules = [ "ahci" "sd_mod" ];
+      boot.kernelModules = [ "kvm-intel" ];
+      boot.extraModulePackages = [ ];
+    
+      nix.maxJobs = 8;
+    })
+  ];
+};
+build4 = {
+  config = {
+    networking = {
+      defaultGateway = "46.4.108.97";
+      interfaces.eth0 = { ipAddress = "46.4.108.125"; prefixLength = 27; };
+      localCommands = ''
+        ip -6 addr add '2a01:4f8:141:4ed::/64' dev 'eth0' || true
+        ip -4 route change '46.4.108.96/27' via '46.4.108.97' dev 'eth0' || true
+        ip -6 route add default via 'fe80::1' dev eth0 || true
+      '';
+      nameservers = [
+        "213.133.98.98"
+        "213.133.99.99"
+        "213.133.100.100"
+        "2a01:4f8:0:a0a1::add:1010"
+        "2a01:4f8:0:a102::add:9999"
+        "2a01:4f8:0:a111::add:9898"
+      ];
+    };
+    services.udev.extraRules = ''
+      ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="6c:62:6d:d9:0a:a7", NAME="eth0"
+    '';
+    users.extraUsers.root.openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB/YASrAWOUiSu57feqS7JUp/enRULZLTWZ/9GUbQ2Qb NixOps client key of build4"
+    ];
+  };
+  imports = [
+    ({
+      swapDevices = [
+        { label = ""; }
+      ];
+      boot.loader.grub.devices = [
+        "/dev/sda"
+        "/dev/sdb"
+      ];
+      fileSystems = {
+        "/" = {
+          fsType = "ext4";
+          label = "root";
+        };
+      };
+    })
+    ({ config, lib, pkgs, ... }:
+    
+    {
+      imports =
+        [ <nixpkgs/nixos/modules/installer/scan/not-detected.nix>
+        ];
+    
+      boot.initrd.availableKernelModules = [ "uhci_hcd" "ahci" "sd_mod" ];
+      boot.kernelModules = [ "kvm-intel" ];
+      boot.extraModulePackages = [ ];
+    
+      nix.maxJobs = 8;
+    })
+  ];
+};
+build2 = {
+  config = {
+    networking = {
+      defaultGateway = "78.46.84.193";
+      interfaces.eth0 = { ipAddress = "78.46.84.196"; prefixLength = 27; };
+      localCommands = ''
+        ip -6 addr add '2a01:4f8:120:12ac::/64' dev 'eth0' || true
+        ip -4 route change '78.46.84.192/27' via '78.46.84.193' dev 'eth0' || true
+        ip -6 route add default via 'fe80::1' dev eth0 || true
+      '';
+      nameservers = [
+        "213.133.98.98"
+        "213.133.99.99"
+        "213.133.100.100"
+        "2a01:4f8:0:a0a1::add:1010"
+        "2a01:4f8:0:a102::add:9999"
+        "2a01:4f8:0:a111::add:9898"
+      ];
+    };
+    services.udev.extraRules = ''
+      ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="40:61:86:be:d1:f1", NAME="eth0"
+    '';
+    users.extraUsers.root.openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINt/FiCtK2N1ZJJalRGzDsotmb4IqFN2ntUa5jbiagsb NixOps client key of build2"
+    ];
+  };
+  imports = [
+    ({
+      swapDevices = [
+        { label = ""; }
+      ];
+      boot.loader.grub.devices = [
+        "/dev/sda"
+        "/dev/sdb"
+      ];
+      fileSystems = {
+        "/" = {
+          fsType = "ext4";
+          label = "root";
+        };
+      };
+    })
+    ({ config, lib, pkgs, ... }:
+    
+    {
+      imports =
+        [ <nixpkgs/nixos/modules/installer/scan/not-detected.nix>
+        ];
+    
+      boot.initrd.availableKernelModules = [ "uhci_hcd" "ahci" "sd_mod" ];
+      boot.kernelModules = [ "kvm-intel" ];
+      boot.extraModulePackages = [ ];
+    
+      nix.maxJobs = 8;
+    })
+  ];
+};
+build3 = {
+  config = {
+    networking = {
+      defaultGateway = "78.46.98.1";
+      interfaces.eth0 = { ipAddress = "78.46.98.22"; prefixLength = 27; };
+      localCommands = ''
+        ip -6 addr add '2a01:4f8:120:8390::/64' dev 'eth0' || true
+        ip -4 route change '78.46.98.0/27' via '78.46.98.1' dev 'eth0' || true
+        ip -6 route add default via 'fe80::1' dev eth0 || true
+      '';
+      nameservers = [
+        "213.133.98.98"
+        "213.133.99.99"
+        "213.133.100.100"
+        "2a01:4f8:0:a0a1::add:1010"
+        "2a01:4f8:0:a102::add:9999"
+        "2a01:4f8:0:a111::add:9898"
+      ];
+    };
+    services.udev.extraRules = ''
+      ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="40:61:86:e9:d5:86", NAME="eth0"
+    '';
+    users.extraUsers.root.openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOxOUSJcUMnB+JJonQ6ZCg2WBOtlKm1kkfD6uyLULh2G NixOps client key of build3"
+    ];
+  };
+  imports = [
+    ({
+      swapDevices = [
+        { label = ""; }
+      ];
+      boot.loader.grub.devices = [
+        "/dev/sda"
+        "/dev/sdb"
+      ];
+      fileSystems = {
+        "/" = {
+          fsType = "ext4";
+          label = "root";
+        };
+      };
+    })
+    ({ config, lib, pkgs, ... }:
+    
+    {
+      imports =
+        [ <nixpkgs/nixos/modules/installer/scan/not-detected.nix>
+        ];
+    
+      boot.initrd.availableKernelModules = [ "uhci_hcd" "ahci" "sd_mod" ];
+      boot.kernelModules = [ "kvm-intel" ];
+      boot.extraModulePackages = [ ];
+    
+      nix.maxJobs = 8;
+    })
+  ];
+};
+build1 = {
+  config = {
+    networking = {
+      defaultGateway = "46.4.65.65";
+      interfaces.eth0 = { ipAddress = "46.4.65.79"; prefixLength = 26; };
+      localCommands = ''
+        ip -6 addr add '2a01:4f8:140:23b3::/64' dev 'eth0' || true
+        ip -4 route change '46.4.65.64/26' via '46.4.65.65' dev 'eth0' || true
+        ip -6 route add default via 'fe80::1' dev eth0 || true
+      '';
+      nameservers = [
+        "213.133.98.98"
+        "213.133.99.99"
+        "213.133.100.100"
+        "2a01:4f8:0:a0a1::add:1010"
+        "2a01:4f8:0:a102::add:9999"
+        "2a01:4f8:0:a111::add:9898"
+      ];
+    };
+    services.udev.extraRules = ''
+      ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:24:21:5b:a3:a1", NAME="eth0"
+    '';
+    users.extraUsers.root.openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII7cOfoJfD+DOjyu8wQSPszykSamYA75z9pGNKMOEjlV NixOps client key of build1"
+    ];
+  };
+  imports = [
+    ({
+      swapDevices = [
+        { label = ""; }
+      ];
+      boot.loader.grub.devices = [
+        "/dev/sda"
+        "/dev/sdb"
+      ];
+      fileSystems = {
+        "/" = {
+          fsType = "ext4";
+          label = "root";
+        };
+      };
+    })
+    ({ config, lib, pkgs, ... }:
+    
+    {
+      imports =
+        [ <nixpkgs/nixos/modules/installer/scan/not-detected.nix>
+        ];
+    
+      boot.initrd.availableKernelModules = [ "uhci_hcd" "ahci" "sd_mod" ];
+      boot.kernelModules = [ "kvm-intel" ];
+      boot.extraModulePackages = [ ];
+    
+      nix.maxJobs = 8;
+    })
+  ];
+};
+}

--- a/machines/eiger.nix
+++ b/machines/eiger.nix
@@ -61,8 +61,8 @@ in {
       nixops
     ];
   };
-  build1 = build-slave;
-  build2 = build-slave;
-  build3 = build-slave;
-  build4 = build-slave;
+  build-1 = build-slave;
+  build-2 = build-slave;
+  build-3 = build-slave;
+  build-4 = build-slave;
 }

--- a/machines/lab-production.nix
+++ b/machines/lab-production.nix
@@ -56,7 +56,7 @@ in {
   murren-9 = mkHetzner "138.201.65.143";
   murren-10 = mkHetzner "138.201.65.147";
 
-  #eiger  = mkHetzner "136.243.111.220";
+  #eiger = mkHetzner "136.243.111.220";
   #build-1 = mkHetzner "46.4.65.79";
   #build-2 = mkHetzner "78.46.84.196";
   #build-3 = mkHetzner "78.46.98.22";

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -78,6 +78,7 @@
 
   # Auto upgrade NixOS
   system.autoUpgrade.enable = true;
+  system.autoUpgrade.dates = "*:0/10";
   systemd.services.nixos-upgrade.environment.NIX_PATH = "/nix/var/nix/profiles/per-user/root/channels/snabblab/:/nix/var/nix/profiles/per-user/root/channels/";
   systemd.services.nixos-upgrade.environment.NIXOS_CONFIG = pkgs.writeText "configuration.nix" ''
     (import <snabblab/machines>).${config.networking.hostName}.config

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -83,6 +83,12 @@
   systemd.services.nixos-upgrade.environment.NIXOS_CONFIG = pkgs.writeText "configuration.nix" ''
     (import <snabblab/machines>).${config.networking.hostName}.config
   '';
+  system.activationScripts.snabblab = ''
+    export PATH=$PATH:${pkgs.gnutar}/bin:${pkgs.xz}/bin
+    NIX_PATH= /run/current-system/sw/bin/nix-channel --remove nixos
+    NIX_PATH= /run/current-system/sw/bin/nix-channel --add https://hydra.snabb.co/channel/custom/domenkozar-sandbox/snabblab/machines.${config.networking.hostName} snabblab
+    NIX_PATH= /run/current-system/sw/bin/nix-channel --update
+  '';
 
   # Expose machines for Hydra slaves
   programs.ssh.extraConfig = ''

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 {
   require = [
@@ -76,7 +76,14 @@
      startAt = "05:40";
    };
 
+  # Auto upgrade NixOS
+  system.autoUpgrade.enable = true;
+  systemd.services.nixos-upgrade.environment.NIX_PATH = "/nix/var/nix/profiles/per-user/root/channels/snabblab/:/nix/var/nix/profiles/per-user/root/channels/";
+  systemd.services.nixos-upgrade.environment.NIXOS_CONFIG = pkgs.writeText "configuration.nix" ''
+    (import <snabblab/machines>).${config.networking.hostName}.config
+  '';
 
+  # Expose machines for Hydra slaves
   programs.ssh.extraConfig = ''
     Host grindelwald.snabb.co
         Hostname lab1.snabb.co

--- a/modules/hydra-master.nix
+++ b/modules/hydra-master.nix
@@ -14,8 +14,6 @@ let
     supportedFeatures = [ "kvm" "nixos-test" ];
   };
 in {
-  imports = [ "${hydraSrc}/hydra-module.nix" ];
-
   # make sure we're using the platform on which hydra is supposed to run
   assertions = lib.singleton {
     assertion = pkgs.system == "x86_64-linux";
@@ -123,11 +121,6 @@ in {
       fi
     '';
   };
-
-  users.users.hydra.uid = config.ids.uids.hydra;
-  users.users.hydra-www.uid = config.ids.uids.hydra-www;
-  users.users.hydra-queue-runner.uid = config.ids.uids.hydra-queue-runner;
-  users.groups.hydra.gid = config.ids.gids.hydra;
 
   networking.firewall.allowedTCPPorts = [ 80 443 ];
 

--- a/modules/sudo-in-builds.nix
+++ b/modules/sudo-in-builds.nix
@@ -14,7 +14,7 @@ let
     '';
   });
 in {
-  nix.chrootDirs = [
+  nix.sandboxPaths = [
     "/var/setuid-wrappers/sudo=/var/setuid-wrappers/sudo-chroot"
     "/var/setuid-wrappers/sudo.real=/var/setuid-wrappers/sudo-chroot.real"
     "${sudoChroot}"
@@ -26,6 +26,6 @@ in {
   security.setuidPrograms = [ "sudo-chroot" ];
 
   # legacy/deprecated solution (no chroot)
-  nix.useChroot = lib.mkForce "relaxed";
+  nix.useSandbox = lib.mkForce "relaxed";
   security.sudo.extraConfig = lib.concatMapStringsSep "\n" (i: "nixbld${toString i} ALL=(ALL) NOPASSWD:ALL") (lib.range 1 config.nix.nrBuildUsers);
 }

--- a/pkgs/mft.nix
+++ b/pkgs/mft.nix
@@ -69,5 +69,8 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  # kernel doesn't work with PIC
+  hardeningDisable = [ "pic" ];
+
   dontStrip = true;
 }

--- a/scripts/convert_export.py
+++ b/scripts/convert_export.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python -p nixops
+
+"""
+Usage:
+
+  $ nixops export -d eiger | ./convert_export.py > eiger-production.nix
+
+"""
+
+import json
+
+from nixops.nix_expr import py2nix, nix2py
+
+
+with open('eiger.export') as f:
+    with open('eiger-production.nix', 'w') as out:
+        deployments = json.load(f)
+        out.write("{")
+        # uses slightly modified logic of nixops/backends/hetzner.py:560
+        for deployment in deployments.values():
+            print "{"
+            for machine, config in deployment['resources'].items():
+                pyconfig = {
+                    'config': dict(
+                         eval(config['hetzner.networkInfo']).items() + {
+                         ('users', 'extraUsers', 'root', 'openssh',
+                         'authorizedKeys', 'keys'): [config['hetzner.sshPublicKey']]
+                    }.items()),
+                    'imports': [nix2py(config['hetzner.fsInfo']), nix2py(config['hetzner.hardwareInfo'])],
+                }
+                print "{0} = {1};".format(machine, py2nix(pyconfig))
+            print "}"


### PR DESCRIPTION
implement https://github.com/snabblab/snabblab-nixos/issues/19
### TODO
- [x] automate replacement of the channel
- [x] deploy all `build-*` servers
- [x] rename `buildX` to `build-X` for consistency with hostnames
- [ ] move `build-*` servers to `machines/lab.nix` (needs NixOps patch for importing/exporting a subset of machines)
- [ ] split `lab-production.nix` into multiple files, one for bootstrapping (NixOps), one autogenerated for Hetzner and one for auto-upgrades
- [ ] deploy all `murren` servers
- [ ] deploy all `lugano` servers
- [ ] deploy all physical servers
- [ ] implement secrets storing to deploy davos https://github.com/snabblab/snabblab-nixos/issues/25
- [ ] document (change README) these changes and how development should be done
- [ ] deploy eiger

https://hydra.snabb.co/jobset/domenkozar-sandbox/snabblab#tabs-channels
