### PR TITLE
[WIP] Test on more Linux distros

### DIFF
--- a/jobsets/snabb.nix
+++ b/jobsets/snabb.nix
@@ -28,10 +28,20 @@ rec {
   });
   distro-builds = with diskImages; builtins.listToAttrs (map
     (diskImage: { inherit (diskImage) name; value = runInLinuxImage (snabb // { inherit diskImage; name = "${snabb.name}-${diskImage.name}";});})
-    [ fedora23x86_64
+    # List of distros that are currently supported according to upstream EOL
+    [
+      # TODO: fedora22
+      fedora23x86_64
+      debian7x86_64
       debian8x86_64
+      ubuntu1204x86_64
+      ubuntu1404x86_64
       ubuntu1510x86_64
       ubuntu1604x86_64
+      # https://en.opensuse.org/Lifetime
+      opensuse132x86_64
+      # https://wiki.centos.org/Download
+      centos71x86_64
       # See https://github.com/snabbco/snabb/pull/899
       # centos65x86_64
     ]);


### PR DESCRIPTION
Added:

- Fedora 23
- Debian 7
- Ubuntu 12.04
- Ubuntu 14.04
- OpenSUSE 13.2
- Centos 7.1

Hydra: https://hydra.snabb.co/jobset/domenkozar-sandbox/distros#tabs-evaluations

Observations:

Ubuntu 12.04 and Debian 7 both fail due to older kernels: https://hydra.snabb.co/eval/1359#tabs-still-fail

Should we do something about them or claim them unsupported?

cc @lukego 