### PR TITLE
benchmarks.Rmd: First report on matrix results

### DIFF
--- a/helpers/reports/benchmarks.Rmd
+++ b/helpers/reports/benchmarks.Rmd
@@ -1,0 +1,101 @@
+# Snabb benchmark report
+
+This is an automatically-generated report that describes an
+automatically-executed benchmarking campaign.
+
+## Initialization
+
+```{r}
+knitr::opts_chunk$set(error=TRUE)
+library(ggplot2)
+dat <- read.csv("/Users/lukego/Downloads/bench (1).csv")
+dat$mtu <- as.factor(dat$mtu)
+d <- as.data.frame(dat)
+
+iperf <- subset(d, subset=(benchmark == "iperf"))
+iperf <- subset(iperf, subset=(mtu == "1500"))
+
+l2fwd <- subset(d, subset=(benchmark=="l2fwd"))
+summary(d)
+```
+
+## Iperf
+
+These benchmarks summarize iperf performance with multiple
+configurations and guest kernel versions.
+
+### Raw data
+
+```{r}
+p <- ggplot(iperf, aes(y=score, x=1, color=kernel))
+p <- p + geom_jitter()
+p + ggtitle("iperf raw data (colored by kernel version)")
+```
+
+### Split by config
+
+```{r}
+p <- ggplot(iperf, aes(x=config, y=score, color=kernel))
+p <- p + geom_jitter()
+p + ggtitle("iperf by config")
+```
+
+### Boxplot
+
+```{r}
+p <- ggplot(iperf, aes(x=config, y=score, color=kernel))
+p <- p + geom_boxplot()
+p <- p + facet_grid(. ~ kernel)
+p + ggtitle("iperf by kernel")
+```
+
+### Tukey test
+
+```{r}
+TukeyHSD(aov(score ~ config, data=iperf))
+```
+
+## l2fwd
+
+These benchmarks summarize DPDK `l2fwd` performance running inside a
+VM with multiple DPDK versions and Virtio-net options.
+
+### Raw data
+
+```{r}
+p <- ggplot(l2fwd, aes(y=score, x=1))
+p <- p + geom_jitter()
+p + ggtitle("l2fwd sample application from DPDK")
+```
+
+### Color by DPDK
+
+```{r}
+p <- ggplot(l2fwd, aes(y=score, x=1, color=dpdk))
+p <- p + geom_jitter()
+p + ggtitle("l2fwd colored by DPDK version")
+```
+
+### Split by DPDK
+
+```{r}
+p <- ggplot(l2fwd, aes(x=config, y=score, color=dpdk))
+p <- p + geom_jitter()
+p <- p + facet_grid(. ~ dpdk)
+p + ggtitle("l2fwd split by DPDK version")
+```
+
+### Boxplot
+
+```{r}
+p <- ggplot(l2fwd, aes(x=config, y=score, color=kernel))
+p <- p + geom_boxplot()
+p <- p + facet_grid(. ~ kernel)
+p + ggtitle("l2fwd boxplot")
+```
+
+### Tukey test
+
+```{r}
+TukeyHSD(aov(score ~ config, data=l2fwd))
+```


### PR DESCRIPTION
Add an Rmarkdown document for a simple report on the results of the
benchmark tests. This report focuses on showing the distribution of
results for each configuration of each benchmark. Further reports can
be added to focus on other aspects such as the relative performance of
different Snabb versions or hardware platforms.

The idea is that the reports can all be generated by the nix
expression that runs a test campaign. I have not tied this in yet and
am hoping for help from @domenkozar on that :-). For now I created
this report by downloading the CSV file containing the results (of
Hydra evaluation 1797) and writing the document in Rstudio.

Creating this report highlighted a couple of issues with the CSV file
in that version:

- The Snabb software version column is N/A. (I would like to make Snabb
version the color for data points but that produced an error with this
CSV.)

- The score for all l2fwd results is N/A. Could be a problem with the
nix expression for producing a CSV row?

Screenshot of one of the graphs:

![screen shot 2016-06-19 at 17 44 36](https://cloud.githubusercontent.com/assets/13791/16178349/9719d49e-3645-11e6-9317-f4ab1950bbb7.png)
