### PR TITLE
Snabb CI modules for davos

### DIFF
--- a/machines/lab.nix
+++ b/machines/lab.nix
@@ -30,8 +30,20 @@ in {
       environment.variables = PCIAssignments.lugano;
 
       # custom NixOS options here
+  };
   davos = { config, pkgs, lib, ... }: defaults // {
       # custom NixOS options here
+      services.snabb_bot.environment =
+        ''
+          export SNABB_TEST_IMAGE=eugeneia/snabb-nfv-test-vanilla
+          export SNABB_PCI0=0000:03:00.0
+          export SNABB_PCI1=0000:03:00.1
+          export SNABB_PCI_INTEL0=0000:03:00.0
+          export SNABB_PCI_INTEL1=0000:03:00.1
+          export SNABB_PCI_INTEL1G0=0000:01:00.0
+          export SNABB_PCI_INTEL1G1=0000:01:00.1
+        '';
+      imports = [ ./../modules/snabb_bot.nix ./../modules/snabb_doc.nix ];
   };
   grindelwald = { config, pkgs, lib, ... }: defaults // {
       # custom NixOS options here

--- a/modules/snabb_bot.nix
+++ b/modules/snabb_bot.nix
@@ -1,0 +1,95 @@
+{ config, pkgs, lib, ... }:
+with lib;
+with pkgs;
+
+let
+  snabb_bot = writeScript "snabb_bot.sh" (readFile (fetchurl {
+     url = "https://raw.githubusercontent.com/eugeneia/snabb/8ae18fa620a81a45731772ba3a551d768e39cd17/src/scripts/snabb_bot.sh";
+     sha256 = "fb94d8697ce9fddc0d5f1c1a7f2c5aec1ccc56559028aa4e1baae387d64baf29";
+  }));
+in {
+  options = {
+
+    services.snabb_bot = {
+
+      credentials = lib.mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          GitHub credentials for SnabbBot instance.
+        '';
+        example = ''
+          username:password
+        '';
+      };
+
+      repo = lib.mkOption {
+        type = types.str;
+        default = "SnabbCo/snabb";
+        description = ''
+          Target GitHub repository for SnabbBot instance.
+        '';
+      };
+
+      dir = lib.mkOption {
+        type = types.str;
+        default = "/tmp/snabb_bot";
+        description = ''
+          Target GitHub repository for SnabbBot instance.
+        '';
+      };
+
+      current = lib.mkOption {
+        type = types.str;
+        default = "master";
+        description = ''
+          The branch to merge pull requests with.
+        '';
+      };
+
+      period = lib.mkOption {
+        type = types.str;
+        default = "* * * * *";
+        description = ''
+          This option defines (in the format used by cron) when the
+          SnabbBot runs. The default is every minute.
+        '';
+      };
+
+      environment = lib.mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          This option defines (in shell format, e.g.: `export FOO=bar; ...')
+          which additional environment variables will be set when
+          SnabbBot runs.
+          ''; };
+
+    };
+
+  };
+
+  config = {
+
+    systemd.services.snabb_bot =
+      { description = "Run SnabbBot";
+        path  = [ bash curl git docker jq pciutils busybox ];
+        script =
+          ''
+            export GITHUB_CREDENTIALS=${config.services.snabb_bot.credentials}
+            export REPO=${config.services.snabb_bot.repo}
+            export SNABBBOTDIR=${config.services.snabb_bot.dir}
+            export CURRENT=${config.services.snabb_bot.current}
+
+            ${config.services.snabb_bot.environment}
+
+            exec flock -x -n /var/lock/snabb_bot ${snabb_bot}
+          '';
+        environment.SSL_CERT_FILE = config.environment.sessionVariables.SSL_CERT_FILE;
+      };
+
+    services.cron.systemCronJobs =
+      [ "${config.services.snabb_bot.period} root ${config.systemd.package}/bin/systemctl start snabb_bot.service" ];
+
+  };
+}

--- a/modules/snabb_doc.nix
+++ b/modules/snabb_doc.nix
@@ -1,0 +1,101 @@
+{ config, pkgs, lib, ... }:
+with lib;
+with pkgs;
+
+let
+  snabb_doc = writeScript "snabb_doc.sh" (readFile (fetchurl {
+     url = "https://raw.githubusercontent.com/eugeneia/snabb/cca676efb3c2603a53eaff7d1aba0683a5fb3738/src/scripts/snabb_doc.sh";
+     sha256 = "6d9e3f397a249a0b2182358d6389504764c3c594ab6d270d2f901d0bcafcd200";
+  }));
+in {
+  options = {
+
+    services.snabb_doc = {
+
+      credentials = lib.mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          GitHub credentials for SnabbDoc instance.
+        '';
+        example = ''
+          username:password
+        '';
+      };
+
+      dir = lib.mkOption {
+        type = types.str;
+        default = "/tmp/snabb_doc";
+        description = ''
+          Target GitHub repository for SnabbDoc instance.
+        '';
+      };
+
+      repo = lib.mkOption {
+        type = types.str;
+        default = "SnabbCo/snabb";
+        description = ''
+          Target GitHub repository for SnabbDoc instance.
+        '';
+      };
+
+
+      docrepo = lib.mkOption {
+        type = types.str;
+        default = "snabbco/snabbco.github.com";
+        description = ''
+          GitHub pages repository to host documentation.
+        '';
+      };
+
+      url = lib.mkOption {
+        type = types.str;
+        default = "https://snabbco.github.com";
+        description = ''
+          URL of documentation site.
+        '';
+      };
+
+      period = lib.mkOption {
+        type = types.str;
+        default = "*/30 * * * *";
+        description = ''
+          This option defines (in the format used by cron) when the
+          SnabbDoc runs. The default is every minute.
+        '';
+      };
+
+    };
+
+  };
+
+  config = {
+
+    systemd.services.snabb_doc =
+      { description = "Run SnabbDoc";
+        path  = [(pkgs.buildEnv {
+          name = "snabb_doc-env";
+          paths = [ bash curl git jq gnumake findutils gcc ditaa pandoc coreutils busybox
+                    (texlive.combine {
+                      inherit (texlive) scheme-small luatex luatexbase sectsty titlesec cprotect bigfoot titling droid;
+                  })];
+          ignoreCollisions = true;
+        })];
+        script =
+          ''
+            export GITHUB_CREDENTIALS=${config.services.snabb_doc.credentials}
+            export SNABBDOCDIR=${config.services.snabb_doc.dir}
+            export REPO=${config.services.snabb_doc.repo}
+            export DOCREPO=${config.services.snabb_doc.docrepo}
+            export DOCURL=${config.services.snabb_doc.url}
+
+            exec flock -x -n /var/lock/snabb_doc ${snabb_doc}
+          '';
+        environment.SSL_CERT_FILE = config.environment.sessionVariables.SSL_CERT_FILE;
+      };
+
+    services.cron.systemCronJobs =
+      [ "${config.services.snabb_doc.period} root ${config.systemd.package}/bin/systemctl start snabb_doc.service" ];
+
+  };
+}


### PR DESCRIPTION
This adds and configures (except for credentials) the SabbBot/SnabbDoc modules for davos.