### PR TITLE
Added report-full-matrix.Rmd

### DIFF
--- a/lib/reports/report-full-matrix.Rmd
+++ b/lib/reports/report-full-matrix.Rmd
@@ -1,0 +1,101 @@
+---
+title: "Full Matrix"
+output:
+  html_document:
+    toc: true
+    toc_float: true
+    toc_depth: 2
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+knitr::opts_chunk$set(error = TRUE)
+knitr::opts_chunk$set(fig.width = 10)
+```
+
+```{r}
+library(ggplot2)
+dat <- read.csv("/Users/lukego/Downloads/bench (3).csv")
+dat$snabb <- as.factor("master") # XXX 'snabb' column missing from this CSV file
+d <- as.data.frame(dat)
+```
+
+# summary
+
+## Density plot
+
+Which Snabb version is better overall?
+
+```{r}
+p <- ggplot(d, aes(x=score, fill=snabb, color=snabb))
+p <- p + geom_density(alpha = 0.1)
+p + ggtitle("Distribution of results for all tests")
+```
+
+## Numeric textual summary
+
+Summary of the data points found in the file.
+
+```{r}
+summary(d)
+```
+
+# basic
+
+```{r}
+basic = subset(d, benchmark == "basic")
+
+p <- ggplot(basic, aes(x=id, y=score, color=snabb))
+p <- p + geom_point()
+p <- p + geom_line()
+p <- p + expand_limits(y=0)
+p + ggtitle("Results ordered by test ID and colored by Snabb version")
+```
+
+# l2fwd
+
+## Density plot
+
+Overview of distribution of scores for all tests. For very broadly comparing two Snabb versions.
+
+```{r}
+l2fwd <- subset(d, benchmark == "l2fwd")
+
+p <- ggplot(l2fwd, aes(x=score, fill=snabb, color=snabb))
+p <- p + geom_density(alpha = 0.1)
+p + ggtitle("Distribution of results across all tests")
+```
+
+## Faceted
+
+```{r, fig.height=40}
+p <- ggplot(l2fwd, aes(x=id, y=score, color=snabb))
+p <- p + geom_point(alpha=0.50)
+p <- p + expand_limits(y=0)
+p <- p + facet_grid(qemu + dpdk ~ config)
+p <- p + geom_boxplot(alpha=0.50)
+p + ggtitle("Distribution of results across all tests, by Snabb version")
+```
+
+# iperf
+
+## Density plot
+
+```{r}
+iperf <- subset(d, benchmark == "iperf")
+
+p <- ggplot(iperf, aes(x=score, fill=snabb, color=snabb))
+p <- p + geom_density(alpha = 0.1)
+p + ggtitle("Distribution of results across all tests")
+```
+
+## Faceted
+
+```{r, fig.height=10}
+p <- ggplot(iperf, aes(x=id, y=score, color=snabb))
+p <- p + geom_point(alpha=0.50)
+p <- p + expand_limits(y=0)
+p <- p + facet_grid(qemu + kernel ~ config)
+p <- p + geom_boxplot(alpha=0.50)
+p + ggtitle("Distribution of results across all tests, by Snabb version")
+```


### PR DESCRIPTION
This draft report compares Snabb versions for performance across a
large set of tests. The overall test results are summarized and
specific test scenarios are also shown individually.

This is not tied in to the build yet but it is intended for use with
the full test matrix and ideally with multple Snabb versions being
compared.

Example rendering here:
http://rpubs.com/lukego/193284

This was developed using the CSV data from Hydra Evaluation 2100:
https://hydra.snabb.co/build/78984