### PR TITLE
Matrix fixes

### DIFF
--- a/jobsets/snabb-matrix.nix
+++ b/jobsets/snabb-matrix.nix
@@ -42,16 +42,17 @@ let
   subQemus = selectQemus qemuVersions;
 
   # benchmarks using a matrix of software and a number of repeats
-  benchmarks-list = (
-    (lib.flatten (map (kPackages:
-    (lib.flatten (map (dpdk:
-    (lib.flatten (map (qemu:
-    (lib.flatten (map (snabb:
-      (selectBenchmarks benchmarkNames { inherit snabb qemu dpdk defaults kPackages; }))
-    snabbs)))
-    subQemus)))
-    (selectDpdks dpdkVersions kPackages))))
-    subKernelPackages)));
+  benchmarks-list = with lib; flatten (
+    concatMap (kPackages:
+      concatMap (dpdk:
+        concatMap (qemu:
+          concatMap (snabb:
+            selectBenchmarks benchmarkNames { inherit snabb qemu dpdk defaults kPackages; }
+          ) snabbs
+        ) subQemus
+      ) (selectDpdks dpdkVersions kPackages)
+    ) subKernelPackages);
+
 in rec {
   # all versions of software used in benchmarks
   software = listDrvToAttrs (lib.flatten [

--- a/lib/test_env.nix
+++ b/lib/test_env.nix
@@ -64,7 +64,7 @@ with pkgs;
        diskSize = 2 * 1020;
      };
      qemu_dpdk_img = qemu_img.override { config = snabb_config_dpdk; };
-   in runCommand "test-env-nix-${dpdk.name}-" rec {
+   in runCommand "test-env-nix-${dpdk.name}" rec {
      passthru = {inherit snabb_config snabb_config_dpdk;};
    } ''
      mkdir -p $out

--- a/lib/test_env.nix
+++ b/lib/test_env.nix
@@ -20,6 +20,9 @@ with pkgs;
          users.extraUsers.root.initialHashedPassword = lib.mkOverride 150 "";
          networking.usePredictableInterfaceNames = false;
 
+         # Make sure telnet serial port is enabled
+         systemd.services."serial-getty@ttyS0".wantedBy = [ "multi-user.target" ];
+
          # Log everything to the serial console.
          services.journald.extraConfig = ''
            ForwardToConsole=yes

--- a/lib/testing.nix
+++ b/lib/testing.nix
@@ -116,6 +116,9 @@ rec {
        patchPhase = ''
          patch -p1 < $testEnvPatch || true
        '';
+       fixupPhase = ''
+         cp qemu*.log $out/ || true
+       '';
      } // removeAttrs attrs [ "times" ]);
    in buildNTimes snabbTest times;
 


### PR DESCRIPTION
These changes will rerun the benchmarks, so let's do them in batches:

- store `qemu` logs if present to $out
- fix `iperf` benchmark with Nix fixtures

Hydra jobset: https://hydra.snabb.co/jobset/domenkozar-sandbox/matrix-testing