### PR TITLE
mkSnabbBench: store also snabb.log

### DIFF
--- a/lib/testing.nix
+++ b/lib/testing.nix
@@ -113,6 +113,7 @@ rec {
        name = "snabb-benchmark-${name}";
        benchName = name;
        alwaysSucceed = true;
+       # patch needed for Snabb v2016.05 and lower
        testEnvPatch = [(fetchurl {
          url = "https://github.com/snabbco/snabb/commit/e78b8b2d567dc54cad5f2eb2bbb9aadc0e34b4c3.patch";
          sha256 = "1nwkj5n5hm2gg14dfmnn538jnkps10hlldav3bwrgqvf5i63srwl";

--- a/lib/testing.nix
+++ b/lib/testing.nix
@@ -90,11 +90,15 @@ rec {
       '';
 
       installPhase = ''
+        runHook preInstall
+
         for f in $(ls $out/* | sort); do
           if [ -f $f ]; then
             echo "file log $f"  >> $out/nix-support/hydra-build-products
           fi
         done
+
+        runHook postInstall
       '';
 
       meta = {
@@ -116,7 +120,7 @@ rec {
        patchPhase = ''
          patch -p1 < $testEnvPatch || true
        '';
-       fixupPhase = ''
+       preInstall = ''
          cp qemu*.log $out/ || true
          cp snabb*.log $out/ || true
        '';

--- a/lib/testing.nix
+++ b/lib/testing.nix
@@ -118,6 +118,7 @@ rec {
        '';
        fixupPhase = ''
          cp qemu*.log $out/ || true
+         cp snabb*.log $out/ || true
        '';
      } // removeAttrs attrs [ "times" ]);
    in buildNTimes snabbTest times;


### PR DESCRIPTION
Parsing logs for failed builds in https://hydra.snabb.co/jobset/lukego/nfv-test-100x shows

```
Failed builds in total: 2341
Failed builds due to 'mapping to host address failedcdata': 0
Failed builds due to being terminated after 2min: 0
Failed builds due to 'packet payload overflow': 0
Failed builds due to qemu telnet timeout: 0
Failed builds due to 'no server running on /tmp/tmux-0/default': 2341
Failed builds due to 'lib/virtio/net_device.lua:254: assertion failed': 0
Failed builds with unknown cause: 0: []
```

`no server running on /tmp/tmux-0/default` could mean either snabb or qemu crashed, since I didn't find anything in qemu logs, let's also store snabb logs if there's some clue there.

I didn't push this into master since all benchmarks would have to be rebuilt.

cc @lukego 