### PR TITLE
[WIP] Add snabbPatches to jobsets/snabb-matrix.nix as input

### DIFF
--- a/jobsets/snabb-matrix.nix
+++ b/jobsets/snabb-matrix.nix
@@ -44,12 +44,12 @@ let
   defaults = { times = numTimesRunBenchmark; };
 
   snabbs = lib.filter (snabb: snabb != null) [
-    (buildNixSnabb snabbAsrc snabbAname)
-    (buildNixSnabb snabbBsrc snabbBname)
-    (buildNixSnabb snabbCsrc snabbCname)
-    (buildNixSnabb snabbDsrc snabbDname)
-    (buildNixSnabb snabbEsrc snabbEname)
-    (buildNixSnabb snabbFsrc snabbFname)
+    (buildNixSnabb snabbAsrc snabbAname snabbPatches)
+    (buildNixSnabb snabbBsrc snabbBname snabbPatches)
+    (buildNixSnabb snabbCsrc snabbCname snabbPatches)
+    (buildNixSnabb snabbDsrc snabbDname snabbPatches)
+    (buildNixSnabb snabbEsrc snabbEname snabbPatches)
+    (buildNixSnabb snabbFsrc snabbFname snabbPatches)
   ];
 
   subKernelPackages = selectKernelPackages kernelVersions;


### PR DESCRIPTION
Useful for applying a patch to all tested branches as
following:

`snabbPatches = [ "https://patch-diff.githubusercontent.com/raw/snabbco/snabb/pull/969.patch 0fcp1yzkjhgrm7rlq2lpcb71nnhih3cwa189b3f14xv2k5yrsbmh"];`
