### PR TITLE
Fix bug where dpdk source is used for qmeu

### DIFF
--- a/jobsets/snabb-matrix.nix
+++ b/jobsets/snabb-matrix.nix
@@ -58,7 +58,7 @@ let
     (buildNixSnabb snabbFsrc snabbFname)
   ];
 
-  customQemu = buildQemuFromSrc qemuAname dpdkAsrc false;
+  customQemu = buildQemuFromSrc qemuAname qemuAsrc false;
   customDpdk = buildDpdkFromSrc dpdkAname dpdkAsrc;
 
   subKernelPackages = selectKernelPackages kernelVersions;


### PR DESCRIPTION
Testing with custom QEMU and DPDK is working well for me once this patch is applied. Can merge into snabblab/snabblab-nixos#62.