### PR TITLE
mkMatrixBenchSoftNFVDPDK: remove useChroot=false (unneeded)

### DIFF
--- a/lib/benchmarks.nix
+++ b/lib/benchmarks.nix
@@ -202,8 +202,6 @@ rec {
         needsNixTestEnv = true;
         testNixEnv = mkNixTestEnv { inherit kPackages dpdk; };
         isDPDK = true;
-        # TODO: get rid of this
-        __useChroot = false;
         hardware = "murren";
         meta = {
           inherit pktsize conf;


### PR DESCRIPTION
Back when I was creating benchmarks, I avoided chroot for dpdk since it fixed an issue for me. 

It was probably one of the transient failures we've fixed today, so I removed chroot avoidance and confirmed dpdk (softnic) works with Snabb `next`: https://hydra.snabb.co/eval/3054