### PR TITLE
Pin kernel for dpdk bench

### DIFF
--- a/jobsets/snabb-matrix.nix
+++ b/jobsets/snabb-matrix.nix
@@ -81,7 +81,7 @@ let
 
 in rec {
   # all versions of software used in benchmarks
-  software = listDrvToAttrs (snabbs ++ subQemus ++ (lib.concatMap (selectDpdks dpdkVersions) subKernelPackages));
+  software = listDrvToAttrs (snabbs ++ subQemus ++ (selectDpdks dpdkVersions linuxPackages_3_18));
   benchmarks = listDrvToAttrs benchmarks-list;
   benchmark-csv = mkBenchmarkCSV benchmarks-list;
   benchmark-reports =

--- a/lib/benchmarks.nix
+++ b/lib/benchmarks.nix
@@ -341,11 +341,11 @@ rec {
    selectQemus = versions:
      if versions == []
      then qemus
-     else map (version: lib.filter (matchesVersionPrefix version) qemus) versions;
+     else lib.concatMap (version: lib.filter (matchesVersionPrefix version) qemus) versions;
    selectDpdks = versions: kPackages:
      if versions == []
      then (dpdks kPackages)
-     else map (version: lib.filter (matchesVersionPrefix version) (dpdks kPackages)) versions;
+     else lib.concatMap (version: lib.filter (matchesVersionPrefix version) (dpdks kPackages)) versions;
    selectKernelPackages = versions:
      if versions == []
      then kernelPackages

--- a/lib/benchmarks.nix
+++ b/lib/benchmarks.nix
@@ -172,7 +172,11 @@ rec {
       '';
     });
   mkMatrixBenchNFVDPDK = { snabb, qemu, kPackages, dpdk, ... }@attrs:
-    mkSnabbBenchTest (attrs.defaults or {} // {
+    # there is no reason to run this benchmark on multiple kernels
+    # 3.18 kernel must be used for older dpdks
+    if (lib.substring 0 4 (kPackages.kernel.version) != "3.18")
+    then []
+    else mkSnabbBenchTest (attrs.defaults or {} // {
       name = "l2fwd_snabb=${versionToAttribute snabb.version or ""}_dpdk=${versionToAttribute dpdk.version}_qemu=${versionToAttribute qemu.version}";
       inherit (attrs) snabb qemu;
       needsNixTestEnv = true;
@@ -196,7 +200,11 @@ rec {
     });
   # using Soft NIC
   mkMatrixBenchSoftNFVDPDK = { snabb, qemu, kPackages, dpdk, pktsize, conf, ... }@attrs:
-      mkSnabbBenchTest (attrs.defaults or {} // {
+    # there is no reason to run this benchmark on multiple kernels
+    # 3.18 kernel must be used for older dpdks
+    if (lib.substring 0 4 (kPackages.kernel.version) != "3.18")
+    then []
+    else mkSnabbBenchTest (attrs.defaults or {} // {
         name = "l2fwd_pktsize=${pktsize}_conf=${conf}_snabb=${versionToAttribute snabb.version or ""}_dpdk=${versionToAttribute dpdk.version}_qemu=${versionToAttribute qemu.version}";
         inherit (attrs) snabb qemu;
         needsNixTestEnv = true;


### PR DESCRIPTION
Dpdk now always uses kernel `3.18`.

This PR also fixes qemu/dpdk selection recently broken in master.