### PR TITLE
mft: 4.3.0-25 -> 4.4.0-44

### DIFF
--- a/pkgs/mft.nix
+++ b/pkgs/mft.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mft-${version}";
-  version = "4.3.0-25";
+  version = "4.4.0-44";
 
   src = fetchurl {
     url = "http://www.mellanox.com/downloads/MFT/${name}.tgz";
-    sha256 = "0vmx8s6fqqrwjwsyaqkmfbjg4xr3gp3rk8xjkczz37i8r6qq5d5j";
+    sha256 = "1psfb67k9pqqayjgdnkb0fchrh2h35d0r1w26m696czn1svsahyq";
   };
 
   buildInputs = [ dpkg file ];
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   # build kernel modules
   buildPhase = ''
-    pushd $TMPDIR/usr/src/kernel-mft-dkms-4.3.0
+    pushd $TMPDIR/usr/src/kernel-mft-dkms-*
     make KSRC=${linux.dev}/lib/modules/${linux.modDirVersion}/build 
     mkdir -p $out/lib/modules/${linux.modDirVersion}/
     cp *.ko $out/lib/modules/${linux.modDirVersion}/


### PR DESCRIPTION
@lukego managed to bump mft, but fwtrace really didn't change. We'll have to contact upstream to get this going, ELF seems to be broken so `patchelf` just complaints.

```
$ patchelf --set-interpreter /nix/store/gwl3ppqj4i730nhd4f50ncl5jc4n97ks-glibc-2.23/lib/ld-linux-x86-64.so.2 /tmp/fwtrace_domenkozar 
wrong ELF type

$ readelf -a /tmp/fwtrace_deploy 
ELF Header:
  Magic:   7f 45 4c 46 02 01 01 02 3e 01 2c 1c 40 40 e0 75 
  Class:                             ELF64
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - NetBSD
  ABI Version:                       62
  Type:                              <unknown>: 3840
  Machine:                           <unknown>: 0x4008
  Version:                           0x5061d20
  Entry point address:               0xc001c04040404040
  Start of program headers:          162131794265835521 (bytes into file)
  Start of section headers:          4629705918808595520 (bytes into file)
  Flags:                             0x65c465c4
  Size of this header:               272 (bytes)
  Size of program headers:           28678 (bytes)
  Number of program headers:         24688
  Size of section headers:           24688 (bytes)
  Number of section headers:         1112
  Section header string table index: 11864 <corrupt: out of range>
readelf: Warning: The e_shentsize field in the ELF header is larger than the size of an ELF section header
readelf: Error: Reading 0x1a2e680 bytes extends past end of file for section headers
readelf: Error: Section headers are not available!
readelf: Warning: The e_phentsize field in the ELF header is larger than the size of an ELF program header
readelf: Error: Reading 0x2a3342a0 bytes extends past end of file for program headers
readelf: Warning: The e_phentsize field in the ELF header is larger than the size of an ELF program header
readelf: Error: Reading 0x2a3342a0 bytes extends past end of file for program headers
```
