### PR TITLE
Add munin monitoring

### DIFF
--- a/machines/eiger.nix
+++ b/machines/eiger.nix
@@ -14,6 +14,7 @@ in {
       ./../modules/common.nix
       ./../modules/hydra-master.nix
       ./../modules/hydra-slave.nix
+      ./../modules/munin.nix
     ];
 
     # https://kernelnewbies.org/Linux_4.7#head-cb7faf5c84d36d6bec87c7f9233bfe2d50b0073a

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -4,6 +4,7 @@
   require = [
     ./users.nix
     ./sudo-in-builds.nix
+    ./munin-node.nix
   ];
 
   i18n.defaultLocale = "en_US.UTF-8";
@@ -77,13 +78,17 @@
 
 
   programs.ssh.extraConfig = ''
-    Host grindelwald
+    Host grindelwald.snabb.co
         Hostname lab1.snabb.co
         Port 2010
 
-    Host interlaken
+    Host interlaken.snabb.co
         Hostname lab1.snabb.co
         Port 2030
+
+    Host davos.snabb.co
+        Hostname lab1.snabb.co
+        Port 2000
   '';
 
   # lets users use sudo without password

--- a/modules/hydra-master.nix
+++ b/modules/hydra-master.nix
@@ -44,7 +44,7 @@ in {
         mandatoryFeatures = [ "lugano" ];
       })
       (commonBuildMachineOpt // {
-        hostName = "grindelwald";
+        hostName = "grindelwald.snabb.co";
         maxJobs = 1;
         mandatoryFeatures = [ "openstack" ];
       })

--- a/modules/munin-node.nix
+++ b/modules/munin-node.nix
@@ -1,0 +1,20 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  hostnameSuffix =
+    if (hasSuffix ".snabb.co" config.networking.hostName)
+    then ""
+    else ".snabb.co";
+in {
+  services.munin-node.enable = true;
+  # It should match the hostname used on Munin master
+  services.munin-node.extraConfig = ''
+    host_name ${config.networking.hostName}${hostnameSuffix}
+  '';
+
+  users.extraUsers.munin.openssh.authorizedKeys.keys = pkgs.lib.singleton ''
+    command="/run/current-system/sw/bin/false" ${pkgs.lib.readFile ./../secrets/id_buildfarm.pub}
+  '';
+}

--- a/modules/munin.nix
+++ b/modules/munin.nix
@@ -1,0 +1,71 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  # TODO: rewrite using declarative configuration
+  hostnames = ["grindelwald.snabb.co" "interlaken.snabb.co" "davos.snabb.co"]
+    ++ (map (i: "lugano-${toString i}.snabb.co") (range 1 4))
+    ++ (map (i: "murren-${toString i}.snabb.co") (range 1 10))
+    ++ (map (i: "build-${toString i}.snabb.co") (range 1 4));
+  muninHosts = concatMapStringsSep "\n" (hostname: ''
+    [${hostname}]
+    address ssh://munin@${hostname} -i /etc/nix/id_buildfarm -W localhost:4949
+
+  '') hostnames;
+in {
+  services.nginx.httpConfig = ''
+      server {
+        listen          80;
+        server_name     munin.snabb.co;
+
+        location /.well-known/acme-challenge {
+          root /var/www/challenges;
+        }
+        location / {
+          return 301 https://$host$request_uri;
+        }
+      }
+
+      server {
+        listen               443 ssl spdy;
+        server_name          munin.snabb.co;
+        keepalive_timeout    70;
+        ssl                  on;
+        ssl_certificate      /var/lib/acme/munin.snabb.co/fullchain.pem;
+        ssl_certificate_key  /var/lib/acme/munin.snabb.co/key.pem;
+
+        location / {
+            root /var/www/munin;
+        }
+      }
+  '';
+
+    services.munin-cron = {
+      enable = true;
+      hosts = ''
+        [eiger.snabb.co]
+        address localhost
+       
+        ${muninHosts}
+      '';
+      extraGlobalConfig = ''
+        contact.me.command mail -s "Munin notification for ''${var:host}" domen@dev.si
+        contact.me.always_send warning critical
+      '';
+    };
+
+  # Allow access to Hydra private ssh key /etc/nix/id_buildfarm
+  users.extraUsers.munin.extraGroups = [ "hydra" ];
+
+
+  security.acme.certs = {
+    "munin.snabb.co" = {
+      email = "munin@snabb.co";
+      user = "nginx";
+      group = "nginx";
+      webroot = "/var/www/challenges";
+      postRun = "systemctl reload nginx.service";
+    };
+  };
+}


### PR DESCRIPTION
Implements https://github.com/snabblab/snabblab-nixos/issues/7

Munin is installed on eiger and accessible at https://munin.snabb.co

Munin connects via ssh to slaves and collects data using telnet to munin-node listening on 4949.