### PR TITLE
Docs+refactor

### DIFF
--- a/jobsets/snabb-matrix.nix
+++ b/jobsets/snabb-matrix.nix
@@ -70,10 +70,10 @@ let
     if (benchmarkNames == [])
     then throw "'benchmarkNames' input list should contain at least one element of: ${concatStringsSep ", " (builtins.attrNames benchmarks)}"
     else
-    concatMap (kPackages:
-      concatMap (dpdk:
-        concatMap (qemu:
-          concatMap (snabb:
+    mergeAttrsMap (kPackages:
+      mergeAttrsMap (dpdk:
+        mergeAttrsMap (qemu:
+          mergeAttrsMap (snabb:
             selectBenchmarks benchmarkNames { inherit snabb qemu dpdk times kPackages; }
           ) snabbs
         ) subQemus
@@ -83,7 +83,7 @@ let
 in rec {
   # All versions of software used in benchmarks
   software = listDrvToAttrs (snabbs ++ subQemus ++ (selectDpdks dpdkVersions linuxPackages_3_18));
-  benchmarks = mergeAttrs benchmarks-list;
+  benchmarks = benchmarks-list;
   benchmark-csv = mkBenchmarkCSV (builtins.attrValues benchmarks);
   benchmark-reports =
     if (reports == [])

--- a/jobsets/snabb-matrix.nix
+++ b/jobsets/snabb-matrix.nix
@@ -83,13 +83,13 @@ let
 in rec {
   # All versions of software used in benchmarks
   software = listDrvToAttrs (snabbs ++ subQemus ++ (selectDpdks dpdkVersions linuxPackages_3_18));
-  benchmarks = listDrvToAttrs benchmarks-list;
-  benchmark-csv = mkBenchmarkCSV benchmarks-list;
+  benchmarks = mergeAttrs benchmarks-list;
+  benchmark-csv = mkBenchmarkCSV (builtins.attrValues benchmarks);
   benchmark-reports =
     if (reports == [])
     then throw "'reports' input list should contain at least one element of: ${lib.concatStringsSep ", " listReports}"
     else lib.listToAttrs (map (reportName:
       { name = reportName;
-        value = mkBenchmarkReport benchmark-csv benchmarks-list reportName;
+        value = mkBenchmarkReport benchmark-csv (builtins.attrValues benchmarks) reportName;
       }) reports);
 }

--- a/jobsets/snabb-matrix.nix
+++ b/jobsets/snabb-matrix.nix
@@ -3,7 +3,7 @@
 
 # Specify how many times each benchmark is repeated
 { numTimesRunBenchmark ? 1
-# Collection of packages used
+# Collection of Nix packages used
 , nixpkgs ? (fetchTarball https://github.com/NixOS/nixpkgs/archive/37e7e86ddd09d200bbdfd8ba8ec2fd2f0621b728.tar.gz)
 # Up to 6 different Snabb branches specified using source and name
 , snabbAsrc
@@ -87,7 +87,7 @@ in rec {
   benchmark-csv = mkBenchmarkCSV benchmarks-list;
   benchmark-reports =
     if (reports == [])
-    then throw "'reports' input list should contain at least one element of: ${lib.concatStringsSep ", " (listReports ../lib/reports)}"
+    then throw "'reports' input list should contain at least one element of: ${lib.concatStringsSep ", " listReports}"
     else lib.listToAttrs (map (reportName:
       { name = reportName;
         value = mkBenchmarkReport benchmark-csv benchmarks-list reportName;

--- a/jobsets/snabb-matrix.nix
+++ b/jobsets/snabb-matrix.nix
@@ -1,5 +1,5 @@
 # Make a matrix benchmark out of Snabb + DPDK + QEMU + Linux (for iperf) combinations
-# and generate a report based on output
+# and generate a report based on the logs
 
 # Specify how many times each benchmark is repeated
 { numTimesRunBenchmark ? 1
@@ -49,6 +49,7 @@ let
   # Legacy naming
   times = numTimesRunBenchmark;
 
+  # Build all specified Snabb branches
   snabbs = lib.filter (snabb: snabb != null) [
     (buildNixSnabb snabbAsrc snabbAname)
     (buildNixSnabb snabbBsrc snabbBname)
@@ -64,7 +65,7 @@ let
   subKernelPackages = selectKernelPackages kernelVersions;
   subQemus = (selectQemus qemuVersions) ++ (if qemuAsrc != null then [customQemu] else []);
 
-  # benchmarks using a matrix of software and a number of repeats
+  # Benchmarks using a matrix of software and a number of repeats
   benchmarks-list = with lib;
     if (benchmarkNames == [])
     then throw "'benchmarkNames' input list should contain at least one element of: ${concatStringsSep ", " (builtins.attrNames benchmarks)}"
@@ -80,7 +81,7 @@ let
     ) subKernelPackages;
 
 in rec {
-  # all versions of software used in benchmarks
+  # All versions of software used in benchmarks
   software = listDrvToAttrs (snabbs ++ subQemus ++ (selectDpdks dpdkVersions linuxPackages_3_18));
   benchmarks = listDrvToAttrs benchmarks-list;
   benchmark-csv = mkBenchmarkCSV benchmarks-list;

--- a/jobsets/snabb.nix
+++ b/jobsets/snabb.nix
@@ -1,3 +1,5 @@
+# Build Snabb, Snabb manual and run tests for given Snabb branch
+
 { pkgs ? (import <nixpkgs> {})
 # which Snabb source directory is used for testing
 , snabbSrc ? (builtins.fetchTarball https://github.com/snabbco/snabb/tarball/next)

--- a/lib/benchmarks.nix
+++ b/lib/benchmarks.nix
@@ -121,7 +121,7 @@ rec {
   mkSnabbBenchTest = { name, times, toCSV, ... }@attrs:
    let
      snabbTest = num: lib.hydraJob (mkSnabbTest ({
-       name = "snabb-benchmark-${name}_num=${toString num}";
+       name = "${name}_num=${toString num}";
        alwaysSucceed = true;
        # patch needed for Snabb v2016.05 and lower
        testEnvPatch = [(fetchurl {
@@ -143,7 +143,7 @@ rec {
          repeatNum = num;
          inherit toCSV;
        } // (attrs.meta or {});
-     } // removeAttrs attrs [ "times" "toCSV" "dpdk" "kPackages" "meta" ]));
+     } // removeAttrs attrs [ "times" "toCSV" "dpdk" "kPackages" "meta" "name"]));
    in map snabbTest (lib.range 1 times);
 
   # Most basic benchmark

--- a/lib/benchmarks.nix
+++ b/lib/benchmarks.nix
@@ -53,7 +53,7 @@ rec {
            } // (attrs.meta or {});
          } // removeAttrs attrs [ "times" "toCSV" "dpdk" "kPackages" "meta" "name"]));
        };
-   in map snabbBenchmark (lib.range 1 times);
+   in mergeAttrsMap snabbBenchmark (lib.range 1 times);
 
   /* Execute `basic1` benchmark.
 
@@ -276,7 +276,7 @@ rec {
 
    # Given a list of names and benchmark inputs/parameters, get benchmarks by their alias and pass them the parameters
    selectBenchmarks = names: params:
-     lib.concatMap (name: (lib.getAttr name benchmarks) params) names;
+     mergeAttrsMap (name: (lib.getAttr name benchmarks) params) names;
 
    # Benchmarks aliases that can be referenced using just a name, i.e. "iperf-filter"
    benchmarks = {

--- a/lib/benchmarks.nix
+++ b/lib/benchmarks.nix
@@ -117,28 +117,11 @@ rec {
     linuxPackages_4_4
   ];
 
-  # functions for building benchmark executing
-
-  dpdkports = {
-    base  = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/snabbnfv-bench.port";
-    nomrg = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/snabbnfv-bench-no-mrg_rxbuf.port";
-    noind = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/snabbnfv-bench-no-indirect_desc.port";
-  };
-
-  iperfports = {
-    base         = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/same_vlan.ports";
-    filter       = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/filter.ports";
-    ipsec        = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/crypto.ports";
-    l2tpv3       = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/tunnel.ports";
-    l2tpv3_ipsec = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/crypto-tunnel.ports";
-  };
-
-  # runs the benchmark without chroot to be able to use pci device assigning
-  mkSnabbBenchTest = { name, times, ... }@attrs:
+  # Function to execute a benchmark
+  mkSnabbBenchTest = { name, times, toCSV, ... }@attrs:
    let
-     snabbTest = lib.makeOverridable mkSnabbTest ({
-       name = "snabb-benchmark-${name}";
-       benchName = name;
+     snabbTest = num: lib.hydraJob (mkSnabbTest ({
+       name = "snabb-benchmark-${name}_num=${toString num}";
        alwaysSucceed = true;
        # patch needed for Snabb v2016.05 and lower
        testEnvPatch = [(fetchurl {
@@ -152,139 +135,123 @@ rec {
          cp qemu*.log $out/ || true
          cp snabb*.log $out/ || true
        '';
-     } // removeAttrs attrs [ "times" ]);
-   in buildNTimes snabbTest times;
+       meta = {
+         snabbVersion = attrs.snabb.version or "";
+         qemuVersion = attrs.qemu.version or "";
+         kernelVersion = attrs.kPackages.kernel.version or "";
+         dpdkVersion = attrs.dpdk.version or "";
+         repeatNum = num;
+         inherit toCSV;
+       } // (attrs.meta or {});
+     } // removeAttrs attrs [ "times" "toCSV" "dpdk" "kPackages" "meta" ]));
+   in map snabbTest (lib.range 1 times);
 
-  mkMatrixBenchBasic = { snabb, ... }@attrs:
+  # Most basic benchmark
+  mkMatrixBenchBasic = { snabb, times, ... }:
     mkSnabbBenchTest {
       name = "basic1_snabb=${versionToAttribute snabb.version or ""}_packets=100e6";
       hardware = "murren";
-      inherit (attrs) snabb times;
+      inherit snabb times;
       checkPhase = ''
         /var/setuid-wrappers/sudo ${snabb}/bin/snabb snabbmark basic1 100e6 |& tee $out/log.txt
       '';
-      meta = {
-        snabbVersion = snabb.version or "";
-        toCSV = drv: ''
-          score=$(awk '/Mpps/ {print $(NF-1)}' < ${drv}/log.txt)
-          ${writeCSV drv "basic" "Mpps"}
-        '';
-      };
+      toCSV = drv: ''
+        score=$(awk '/Mpps/ {print $(NF-1)}' < ${drv}/log.txt)
+        ${writeCSV drv "basic" "Mpps"}
+      '';
     };
-  mkMatrixBenchNFVIperf = { snabb, qemu, kPackages, conf ? "NA", hardware ? "lugano", ... }@attrs:
-    mkSnabbBenchTest {
-      name = "iperf_conf=${conf}_snabb=${versionToAttribute snabb.version or ""}_kernel=${versionToAttribute kPackages.kernel.version}_qemu=${versionToAttribute qemu.version}";
-      inherit (attrs) snabb times qemu;
-      inherit hardware;
-      testNixEnv = mkNixTestEnv { inherit kPackages; };
-      meta = {
-        inherit conf;
-        snabbVersion = snabb.version or "";
-        qemuVersion = qemu.version;
-        kernelVersion = kPackages.kernel.version;
-        toCSV = drv: ''
-          score=$(awk '/^IPERF-/ { print $2 }' < ${drv}/log.txt)
-          ${writeCSV drv "iperf" "Gbps"}
-       '';
+
+  mkMatrixBenchNFVIperf = { snabb, qemu, kPackages, conf ? "NA", hardware ? "lugano", times, ... }:
+    let
+      iperfports = {
+        base         = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/same_vlan.ports";
+        filter       = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/filter.ports";
+        ipsec        = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/crypto.ports";
+        l2tpv3       = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/tunnel.ports";
+        l2tpv3_ipsec = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/crypto-tunnel.ports";
       };
+    in mkSnabbBenchTest {
+      name = "iperf_conf=${conf}_snabb=${versionToAttribute snabb.version or ""}_kernel=${versionToAttribute kPackages.kernel.version}_qemu=${versionToAttribute qemu.version}";
+      inherit hardware kPackages snabb times qemu;
+      testNixEnv = mkNixTestEnv { inherit kPackages; };
+      toCSV = drv: ''
+        score=$(awk '/^IPERF-/ { print $2 }' < ${drv}/log.txt)
+        ${writeCSV drv "iperf" "Gbps"}
+      '';
+      meta = { inherit conf; };
       needsNixTestEnv = true;
+      SNABB_IPERF_BENCH_CONF = iperfports.${conf} or "";
       checkPhase = ''
-        export SNABB_IPERF_BENCH_CONF=${iperfports.${conf} or ""}
         cd src
         /var/setuid-wrappers/sudo -E program/snabbnfv/selftest.sh bench |& tee $out/log.txt
       '';
     };
-  mkMatrixBenchNFVDPDK = { snabb, qemu, kPackages, dpdk, ... }@attrs:
+
+  # If hardware == "murren", then conf and pktsize are required and the benchmark runs NICless
+  mkMatrixBenchNFVDPDK = { snabb, qemu, kPackages, dpdk, hardware ? "lugano", times, pktsize ? "", conf ? "", ... }:
+    let
+      dpdkports = {
+        base  = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/snabbnfv-bench.port";
+        nomrg = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/snabbnfv-bench-no-mrg_rxbuf.port";
+        noind = "program/snabbnfv/test_fixtures/nfvconfig/test_functions/snabbnfv-bench-no-indirect_desc.port";
+      };
+    in
     # there is no reason to run this benchmark on multiple kernels
     # 3.18 kernel must be used for older dpdks
     if (lib.substring 0 4 (kPackages.kernel.version) != "3.18")
     then []
-    else mkSnabbBenchTest {
-      name = "l2fwd_snabb=${versionToAttribute snabb.version or ""}_dpdk=${versionToAttribute dpdk.version}_qemu=${versionToAttribute qemu.version}";
-      inherit (attrs) snabb qemu times;
+    else mkSnabbBenchTest rec {
+      name = "l2fwd_pktsize=${pktsize}_conf=${conf}_snabb=${versionToAttribute snabb.version or ""}_dpdk=${versionToAttribute dpdk.version}_qemu=${versionToAttribute qemu.version}";
+      inherit snabb qemu times hardware dpdk kPackages;
       needsNixTestEnv = true;
       testNixEnv = mkNixTestEnv { inherit kPackages dpdk; };
       isDPDK = true;
-      hardware = "lugano";
-      meta = {
-        snabbVersion = snabb.version or "";
-        qemuVersion = qemu.version;
-        kernelVersion = kPackages.kernel.version;
-        dpdkVersion = dpdk.version;
-        toCSV = drv: ''
-          score=$(awk '/^Rate\(Mpps\):/ { print $2 }' < ${drv}/log.txt)
-          ${writeCSV drv "l2fwd" "Mpps"}
-       '';
-      };
-      checkPhase = ''
-        cd src
-        /var/setuid-wrappers/sudo -E timeout 120 program/snabbnfv/packetblaster_bench.sh |& tee $out/log.txt
+      toCSV = drv: ''
+        score=$(awk '/^Rate\(Mpps\):/ { print $2 }' < ${drv}/log.txt)
+        ${writeCSV drv "l2fwd" "Mpps"}
       '';
-    };
-  # using Soft NIC
-  mkMatrixBenchSoftNFVDPDK = { snabb, qemu, kPackages, dpdk, pktsize, conf, ... }@attrs:
-    # there is no reason to run this benchmark on multiple kernels
-    # 3.18 kernel must be used for older dpdks
-    if (lib.substring 0 4 (kPackages.kernel.version) != "3.18")
-    then []
-    else mkSnabbBenchTest {
-        name = "l2fwd_pktsize=${pktsize}_conf=${conf}_snabb=${versionToAttribute snabb.version or ""}_dpdk=${versionToAttribute dpdk.version}_qemu=${versionToAttribute qemu.version}";
-        inherit (attrs) snabb qemu times;
-        needsNixTestEnv = true;
-        testNixEnv = mkNixTestEnv { inherit kPackages dpdk; };
-        isDPDK = true;
-        hardware = "murren";
-        meta = {
-          inherit pktsize conf;
-          snabbVersion = snabb.version or "";
-          qemuVersion = qemu.version;
-          kernelVersion = kPackages.kernel.version;
-          dpdkVersion = dpdk.version;
-          toCSV = drv: ''
-            score=$(awk '/^Rate\(Mpps\):/ { print $2 }' < ${drv}/log.txt)
-            ${writeCSV drv "l2fwd" "Mpps"}
-         '';
-        };
-        checkPhase = ''
+      meta = { inherit pktsize conf; };
+      checkPhase = 
+        if hardware == "murren"
+        then ''
           cd src
 
           export SNABB_PACKET_SIZES=${pktsize}
           export SNABB_DPDK_BENCH_CONF=${dpdkports.${conf}}
-          /var/setuid-wrappers/sudo -E timeout 160 program/snabbnfv/dpdk_bench.sh |& tee $out/log.txt
+          /var/setuid-wrappers/sudo -E timeout 120 program/snabbnfv/dpdk_bench.sh |& tee $out/log.txt
+        '' else ''
+          cd src
+          /var/setuid-wrappers/sudo -E timeout 120 program/snabbnfv/packetblaster_bench.sh |& tee $out/log.txt
         '';
-      };
-  mkMatrixBenchPacketblaster = { snabb, ... }@attrs:
+    };
+
+  mkMatrixBenchPacketblaster = { snabb, times, ... }:
     mkSnabbBenchTest {
       name = "${snabb.name}-packetblaster-64";
-      inherit (attrs) snabb times;
+      inherit snabb times;
       hardware = "lugano";
-      meta = {
-        snabbVersion = snabb.version or "";
-        toCSV = drv: ''
-          pps=$(cat ${drv}/log.txt | grep TXDGPC | cut -f 3 | sed s/,//g)
-          score=$(echo "scale=2; $pps / 1000000" | bc)
-          ${writeCSV drv "blast" "Mpps"}
-        '';
-      };
+      toCSV = drv: ''
+        pps=$(cat ${drv}/log.txt | grep TXDGPC | cut -f 3 | sed s/,//g)
+        score=$(echo "scale=2; $pps / 1000000" | bc)
+        ${writeCSV drv "blast" "Mpps"}
+      '';
       checkPhase = ''
         cd src
         /var/setuid-wrappers/sudo ${snabb}/bin/snabb packetblaster replay --duration 1 \
           program/snabbnfv/test_fixtures/pcap/64.pcap "$SNABB_PCI_INTEL0" |& tee $out/log.txt
       '';
     };
-  mkMatrixBenchPacketblasterSynth = { snabb, ... }@attrs:
+
+  mkMatrixBenchPacketblasterSynth = { snabb, times, ... }:
     mkSnabbBenchTest {
       name = "${snabb.name}-packetblaster-synth-64";
-      inherit (attrs) snabb times;
+      inherit snabb times;
       hardware = "lugano";
-      meta = {
-        snabbVersion = snabb.version or "";
-        toCSV = drv: ''
-          pps=$(cat ${drv}/log.txt | grep TXDGPC | cut -f 3 | sed s/,//g)
-          score=$(echo "scale=2; $pps / 1000000" | bc)
-          ${writeCSV drv "blastsynth" "Mpps"}
-        '';
-      };
+      toCSV = drv: ''
+        pps=$(cat ${drv}/log.txt | grep TXDGPC | cut -f 3 | sed s/,//g)
+        score=$(echo "scale=2; $pps / 1000000" | bc)
+        ${writeCSV drv "blastsynth" "Mpps"}
+      '';
       checkPhase = ''
         /var/setuid-wrappers/sudo ${snabb}/bin/snabb packetblaster synth \
           --src 11:11:11:11:11:11 --dst 22:22:22:22:22:22 --sizes 64 \
@@ -293,59 +260,63 @@ rec {
     };
 
 
-  # Functions providing commands to convert logs to CSV
-
+  # Function providing commands to convert logs to CSV
   writeCSV = drv: benchName: unit: ''
     if test -z "$score"; then score="NA"; fi
     echo ${benchName},${drv.meta.pktsize or "NA"},${drv.meta.conf or "NA"},${drv.meta.snabbVersion or "NA"},${drv.meta.kernelVersion or "NA"},${drv.meta.qemuVersion or "NA"},${drv.meta.dpdkVersion or "NA"},${toString drv.meta.repeatNum},$score,${unit} >> $out/bench.csv
   '';
 
-  # generate CSV out of logs
-  # TODO: uses writeText until following is merged https://github.com/NixOS/nixpkgs/pull/15803
-  mkBenchmarkCSV = benchmarkList: stdenv.mkDerivation {
-    name = "snabb-report-csv";
-    buildInputs = [ pkgs.gawk pkgs.bc ];
-    preferLocalBuild = true;
-    builder = writeText "csv-builder.sh" ''
-      source $stdenv/setup
-      mkdir -p $out/nix-support
-
-      echo "benchmark,pktsize,config,snabb,kernel,qemu,dpdk,id,score,unit" > $out/bench.csv
-      ${lib.concatMapStringsSep "\n" (drv: drv.meta.toCSV drv) benchmarkList}
-
-      # Make CSV file available via Hydra
-      echo "file CSV $out/bench.csv" >> $out/nix-support/hydra-build-products
-    '';
-   };
-
-   # TODO: use writeText until runCommand uses passAsFile (16.09)
-   mkBenchmarkReport = benchmark-csv: benchmarks-list: reportName: stdenv.mkDerivation {
-     name = "snabb-report";
-     buildInputs = [ rPackages.rmarkdown rPackages.ggplot2 rPackages.dplyr R pandoc which ];
-     # Build reports on Hydra localhost to spare time on copying
+  # generate CSV out of collection of logs
+  mkBenchmarkCSV = benchmarkList:
+   stdenv.mkDerivation {
+     name = "snabb-report-csv";
+     buildInputs = [ pkgs.gawk pkgs.bc ];
+     # Build CSV on Hydra localhost to spare time on copying
      requiredSystemFeatures = [ "local" ];
+     # TODO: uses writeText until following is merged https://github.com/NixOS/nixpkgs/pull/15803
      builder = writeText "csv-builder.sh" ''
        source $stdenv/setup
-
-       # Store all logs
        mkdir -p $out/nix-support
-       ${lib.concatMapStringsSep "\n" (drv: "cat ${drv}/log.txt > $out/${drv.name}-${toString drv.meta.repeatNum}.log") benchmarks-list}
-       tar cfJ logs.tar.xz -C $out .
-       mv logs.tar.xz $out/
-       echo "file tarball $out/logs.tar.xz" >> $out/nix-support/hydra-build-products
 
-       # Create markdown report
-       cp ${../lib/reports + "/${reportName}.Rmd"} ./report.Rmd
-       cp ${benchmark-csv}/bench.csv .
-       cat bench.csv
-       cat report.Rmd
-       echo "library(rmarkdown); render('report.Rmd')" | R --no-save
-       cp report.html $out
-       echo "file HTML $out/report.html"  >> $out/nix-support/hydra-build-products
-       echo "nix-build out $out" >> $out/nix-support/hydra-build-products
+       echo "benchmark,pktsize,config,snabb,kernel,qemu,dpdk,id,score,unit" > $out/bench.csv
+       ${lib.concatMapStringsSep "\n" (drv: drv.meta.toCSV drv) benchmarkList}
+
+       # Make CSV file available via Hydra
+       echo "file CSV $out/bench.csv" >> $out/nix-support/hydra-build-products
      '';
-   };
+    };
 
+   # Generate a report 
+   mkBenchmarkReport = benchmark-csv: benchmarks-list: reportName:
+    stdenv.mkDerivation {
+      name = "snabb-report";
+      buildInputs = [ rPackages.rmarkdown rPackages.ggplot2 rPackages.dplyr R pandoc which ];
+      # Build reports on Hydra localhost to spare time on copying
+      requiredSystemFeatures = [ "local" ];
+      # TODO: use writeText until runCommand uses passAsFile (16.09)
+      builder = writeText "csv-builder.sh" ''
+        source $stdenv/setup
+
+        # Store all logs
+        mkdir -p $out/nix-support
+        ${lib.concatMapStringsSep "\n" (drv: "cat ${drv}/log.txt > $out/${drv.name}-${toString drv.meta.repeatNum}.log") benchmarks-list}
+        tar cfJ logs.tar.xz -C $out .
+        mv logs.tar.xz $out/
+        echo "file tarball $out/logs.tar.xz" >> $out/nix-support/hydra-build-products
+
+        # Create markdown report
+        cp ${../lib/reports + "/${reportName}.Rmd"} ./report.Rmd
+        cp ${benchmark-csv}/bench.csv .
+        cat bench.csv
+        cat report.Rmd
+        echo "library(rmarkdown); render('report.Rmd')" | R --no-save
+        cp report.html $out
+        echo "file HTML $out/report.html"  >> $out/nix-support/hydra-build-products
+        echo "nix-build out $out" >> $out/nix-support/hydra-build-products
+      '';
+    };
+
+   # Generate a list of names of available reports
    # Path -> [String]
    listReports = path:
      map (name: lib.removeSuffix ".Rmd" name)
@@ -376,20 +347,23 @@ rec {
    # All preconfigured benchmarks that can be referenced using just a name, i.e. "iperf-filter"
    benchmarks = {
      basic = mkMatrixBenchBasic;
+
      packetblaster = mkMatrixBenchPacketblaster;
      packetblaster-synth = mkMatrixBenchPacketblasterSynth;
+
      iperf = mkMatrixBenchNFVIperf;
      iperf-base = params: mkMatrixBenchNFVIperf (params // {conf = "base"; hardware = "murren";});
      iperf-filter = params: mkMatrixBenchNFVIperf (params // {conf = "filter"; hardware = "murren";});
      iperf-ipsec = params: mkMatrixBenchNFVIperf (params // {conf = "ipsec"; hardware = "murren";});
      iperf-l2tpv3 = params: mkMatrixBenchNFVIperf (params // {conf = "l2tpv3"; hardware = "murren";});
      iperf-l2tpv3-ipsec = params: mkMatrixBenchNFVIperf (params // {conf = "l2tpv3_ipsec"; hardware = "murren";});
+
      dpdk = mkMatrixBenchNFVDPDK;
-     dpdk-soft-base-256 = params: mkMatrixBenchSoftNFVDPDK (params // {pktsize = "256"; conf = "base";});
-     dpdk-soft-nomrg-256 = params: mkMatrixBenchSoftNFVDPDK (params // {pktsize = "256"; conf = "nomrg";});
-     dpdk-soft-noind-256 = params: mkMatrixBenchSoftNFVDPDK (params // {pktsize = "256"; conf = "noind";});
-     dpdk-soft-base-64 = params: mkMatrixBenchSoftNFVDPDK (params // {pktsize = "64"; conf = "base";});
-     dpdk-soft-nomrg-64 = params: mkMatrixBenchSoftNFVDPDK (params // {pktsize = "64"; conf = "nomrg";});
-     dpdk-soft-noind-64 = params: mkMatrixBenchSoftNFVDPDK (params // {pktsize = "64"; conf = "noind";});
+     dpdk-soft-base-256 = params: mkMatrixBenchNFVDPDK (params // {pktsize = "256"; conf = "base"; hardware = "murren";});
+     dpdk-soft-nomrg-256 = params: mkMatrixBenchNFVDPDK (params // {pktsize = "256"; conf = "nomrg"; hardware = "murren";});
+     dpdk-soft-noind-256 = params: mkMatrixBenchNFVDPDK (params // {pktsize = "256"; conf = "noind"; hardware = "murren";});
+     dpdk-soft-base-64 = params: mkMatrixBenchNFVDPDK (params // {pktsize = "64"; conf = "base"; hardware = "murren";});
+     dpdk-soft-nomrg-64 = params: mkMatrixBenchNFVDPDK (params // {pktsize = "64"; conf = "nomrg"; hardware = "murren";});
+     dpdk-soft-noind-64 = params: mkMatrixBenchNFVDPDK (params // {pktsize = "64"; conf = "noind"; hardware = "murren";});
    };
 }

--- a/lib/benchmarks.nix
+++ b/lib/benchmarks.nix
@@ -205,7 +205,6 @@ rec {
       inherit snabb qemu times hardware dpdk kPackages;
       needsNixTestEnv = true;
       testNixEnv = mkNixTestEnv { inherit kPackages dpdk; };
-      isDPDK = true;
       toCSV = drv: ''
         score=$(awk '/^Rate\(Mpps\):/ { print $2 }' < ${drv}/log.txt)
         ${writeCSV drv "l2fwd" "Mpps"}

--- a/lib/benchmarks.nix
+++ b/lib/benchmarks.nix
@@ -6,6 +6,7 @@ with pkgs;
 with (import ./testing.nix { inherit pkgs; });
 
 rec {
+  # build* functions are responsible for building software given their source or version
   buildSnabb = version: hash:
      snabbswitch.overrideDerivation (super: {
        name = "snabb-${version}";
@@ -354,7 +355,7 @@ rec {
    selectBenchmarks = names: params:
      lib.concatMap (name: (lib.getAttr name benchmarks) params) names;
 
-   # helper function for package selections
+   # Returns true if version is a prefix of drv.version
    matchesVersionPrefix = version: drv:
      lib.hasPrefix version (lib.getVersion drv);
 
@@ -372,6 +373,7 @@ rec {
      then kernelPackages
      else lib.concatMap (version: lib.filter (kPackages: lib.hasPrefix version (lib.getVersion kPackages.kernel)) kernelPackages) versions;
 
+   # All preconfigured benchmarks that can be referenced using just a name, i.e. "iperf-filter"
    benchmarks = {
      basic = mkMatrixBenchBasic;
      packetblaster = mkMatrixBenchPacketblaster;

--- a/lib/benchmarks.nix
+++ b/lib/benchmarks.nix
@@ -29,25 +29,30 @@ rec {
        url = "https://github.com/snabbco/snabb/commit/e78b8b2d567dc54cad5f2eb2bbb9aadc0e34b4c3.patch";
        sha256 = "1nwkj5n5hm2gg14dfmnn538jnkps10hlldav3bwrgqvf5i63srwl";
      };
-     snabbBenchmark = num: lib.hydraJob (mkSnabbTest ({
-       name = "${name}_num=${toString num}";
-       alwaysSucceed = true;
-       patchPhase = ''
-         patch -p1 < ${testEnvPatch} || true
-       '';
-       preInstall = ''
-         cp qemu*.log $out/ || true
-         cp snabb*.log $out/ || true
-       '';
-       meta = {
-         snabbVersion = attrs.snabb.version or "";
-         qemuVersion = attrs.qemu.version or "";
-         kernelVersion = attrs.kPackages.kernel.version or "";
-         dpdkVersion = attrs.dpdk.version or "";
-         repeatNum = num;
-         inherit toCSV;
-       } // (attrs.meta or {});
-     } // removeAttrs attrs [ "times" "toCSV" "dpdk" "kPackages" "meta" "name"]));
+     snabbBenchmark = num:
+       let
+         name' = "${name}_num=${toString num}";
+       in {
+         ${name'} = lib.hydraJob (mkSnabbTest ({
+           name = name';
+           alwaysSucceed = true;
+           patchPhase = ''
+             patch -p1 < ${testEnvPatch} || true
+           '';
+           preInstall = ''
+             cp qemu*.log $out/ || true
+             cp snabb*.log $out/ || true
+           '';
+           meta = {
+             snabbVersion = attrs.snabb.version or "";
+             qemuVersion = attrs.qemu.version or "";
+             kernelVersion = attrs.kPackages.kernel.version or "";
+             dpdkVersion = attrs.dpdk.version or "";
+             repeatNum = num;
+             inherit toCSV;
+           } // (attrs.meta or {});
+         } // removeAttrs attrs [ "times" "toCSV" "dpdk" "kPackages" "meta" "name"]));
+       };
    in map snabbBenchmark (lib.range 1 times);
 
   /* Execute `basic1` benchmark.

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -5,4 +5,5 @@ with pkgs;
 let
   benchmarks = import ./benchmarks.nix { pkgs = pkgs; };
   testing = import ./testing.nix { pkgs = pkgs; };
-in testing // benchmarks
+  software = import ./software.nix { pkgs = pkgs; };
+in testing // benchmarks // software

--- a/lib/software.nix
+++ b/lib/software.nix
@@ -1,0 +1,117 @@
+{ pkgs }:
+
+# build* functions are responsible for building software given their source or version
+
+with pkgs;
+
+rec {
+  # Build Snabb using git version tag
+  buildSnabb = version: hash:
+     snabbswitch.overrideDerivation (super: {
+       name = "snabb-${version}";
+       inherit version;
+       src = fetchFromGitHub {
+          owner = "snabbco";
+          repo = "snabb";
+          rev = "v${version}";
+          sha256 = hash;
+        };
+     });
+
+ # Build snabb using nix store path provided by builtins.fetchTarball or Hydra git input
+ buildNixSnabb = snabbSrc: version:
+   if snabbSrc == null
+   then null
+   else
+     (callPackage snabbSrc {}).overrideDerivation (super:
+       {
+         name = super.name + version;
+         inherit version;
+       }
+     );
+
+  buildQemu = version: hash: applySnabbPatch:
+    let
+       src = fetchurl {
+         url = "http://wiki.qemu.org/download/qemu-${version}.tar.bz2";
+         sha256 = hash;
+       };
+    in buildQemuFromSrc version src applySnabbPatch;
+
+  buildQemuFromSrc = version: src: applySnabbPatch:
+     let
+       snabbPatch = pkgs.fetchurl {
+         url = "https://github.com/SnabbCo/qemu/commit/f393aea2301734647fdf470724433f44702e3fb9.patch";
+         sha256 = "0hpnfdk96rrdaaf6qr4m4pgv40dw7r53mg95f22axj7nsyr8d72x";
+         name = "snabb-patch";
+       };
+     in qemu.overrideDerivation (super: {
+       name = "qemu-${version}" + lib.optionalString applySnabbPatch "-with-snabbpatch";
+       version = version + lib.optionalString applySnabbPatch "-with-snabbpatch";
+       inherit src;
+       patchPhase = ''
+         substituteInPlace Makefile --replace \
+           "install-datadir install-localstatedir" \
+           "install-datadir" \
+           --replace "install-sysconfig " ""
+       '' + lib.optionalString applySnabbPatch ''
+         patch -p1 < ${snabbPatch}
+       '';
+     });
+
+  buildDpdk = version: hash: kPackages:
+    let
+      src = fetchurl {
+        url = "http://dpdk.org/browse/dpdk/snapshot/dpdk-${version}.tar.gz";
+        sha256 = hash;
+      };
+    in buildDpdkFromSrc version src kPackages;
+
+  buildDpdkFromSrc = version: src: kPackages:
+    let
+      origDpdk = callPackage ../pkgs/dpdk.nix { kernel = kPackages.kernel; };
+      needsGCC49 = lib.any (v: v == version) ["1.7.1" "1.8.0" "2.0.0" "2.1.0"];
+      dpdk = if needsGCC49
+             then (origDpdk.override { stdenv = overrideCC stdenv gcc48;})
+             else origDpdk;
+    in dpdk.overrideDerivation (super: {
+      name = "dpdk-${version}-${kPackages.kernel.version}";
+      inherit version;
+      prePatch = ''
+        find . -type f -exec sed -i 's/-Werror//' {} \;
+      '';
+      inherit src;
+    });
+
+  # Define software stacks using a list
+
+  # DPDKs are a special case, because they need kernelPackages as input to build
+  dpdks = kPackages: map (dpdk: dpdk kPackages) [
+    (buildDpdk "16.07" "1sgh55w3xpc0lb70s74cbyryxdjijk1fbv9b25jy8ms3lxaj966c")
+    (buildDpdk "16.04" "0yrz3nnhv65v2jzz726bjswkn8ffqc1sr699qypc9m78qrdljcfn")
+    (buildDpdk "2.2.0" "03b1pliyx5psy3mkys8j1mk6y2x818j6wmjrdvpr7v0q6vcnl83p")
+    (buildDpdk "2.1.0" "0h1lkalvcpn8drjldw50kipnf88ndv2wvflgkkyrmya5ga325czp")
+    (buildDpdk "2.0.0" "0gzzzgmnl1yzv9vs3bbdfgw61ckiakgqq93b9pc4v92vpsiqjdv4")
+    (buildDpdk "1.8.0" "0f8rvvp2y823ipnxszs9lh10iyiczkrhh172h98kb6fr1f1qclwz")
+    # TODO: needs older glibc
+    #(buildDpdk "1.7.1" "0yd60ww5xhf0dfl2x1pqx1m2363b2b7zp89mcya86j20gi3bgvlx")
+  ];
+
+  qemus = [
+    (buildQemu "2.1.3" "0h0ayrlr4kj74fb920mv0wh9d11d0nvnm70wplwijh3cdw7gss4v" true)
+    (buildQemu "2.1.3" "0h0ayrlr4kj74fb920mv0wh9d11d0nvnm70wplwijh3cdw7gss4v" false)
+    (buildQemu "2.2.1" "181m2ddsg3adw8y5dmimsi8x678imn9f6i5p20zbhi7pdr61a5s6" false)
+    (buildQemu "2.3.1" "0px1vhkglxzjdxkkqln98znv832n1sn79g5inh3aw72216c047b6" false)
+    (buildQemu "2.4.1" "0xx1wc7lj5m3r2ab7f0axlfknszvbd8rlclpqz4jk48zid6czmg3" false)
+    (buildQemu "2.5.1" "0b2xa8604absdmzpcyjs7fix19y5blqmgflnwjzsp1mp7g1m51q2" false)
+    (buildQemu "2.6.0" "1v1lhhd6m59hqgmiz100g779rjq70pik5v4b3g936ci73djlmb69" false)
+  ];
+
+  kernelPackages = [
+    linuxPackages_3_14
+    linuxPackages_3_18
+    linuxPackages_4_1
+    linuxPackages_4_3
+    linuxPackages_4_4
+  ];
+}

--- a/lib/test_env.nix
+++ b/lib/test_env.nix
@@ -1,4 +1,4 @@
-# Build two Qemu guest images:
+# Build two NixOS Qemu guest images:
 
 # qemu_img: Plain NixOS guest with some tools like 
 # dpdk_img: Same as the above plus dpdk l2fwd tied to an interface

--- a/lib/test_env.nix
+++ b/lib/test_env.nix
@@ -74,9 +74,7 @@ with pkgs;
        diskSize = 2 * 1020;
      };
      qemu_dpdk_img = qemu_img.override { config = snabb_config_dpdk; };
-   in runCommand "test-env-nix-${dpdk.name}" rec {
-     passthru = {inherit snabb_config snabb_config_dpdk;};
-   } ''
+   in runCommand "test-env-nix-${dpdk.name}" {} ''
      mkdir -p $out
      ln -s ${qemu_img}/nixos.img $out/qemu.img
      ln -s ${qemu_dpdk_img}/nixos.img $out/qemu-dpdk.img

--- a/lib/test_env.nix
+++ b/lib/test_env.nix
@@ -1,3 +1,8 @@
+# Build two Qemu guest images:
+
+# qemu_img: Plain NixOS guest with some tools like 
+# dpdk_img: Same as the above plus dpdk l2fwd tied to an interface
+
 { pkgs }:
 
 with pkgs;
@@ -9,7 +14,9 @@ with pkgs;
      snabb_modules = [
        <nixpkgs/nixos/modules/profiles/qemu-guest.nix>
        ({config, pkgs, ...}: {
+         # Needed tools inside the guest
          environment.systemPackages = with pkgs; [ inetutils screen python pciutils ethtool tcpdump (hiPrio netcat-openbsd) iperf2 ];
+
          fileSystems."/".device = "/dev/disk/by-label/nixos";
          boot.loader.grub.device = "/dev/sda";
 
@@ -23,7 +30,7 @@ with pkgs;
          # Make sure telnet serial port is enabled
          systemd.services."serial-getty@ttyS0".wantedBy = [ "multi-user.target" ];
 
-         # Log everything to the serial console.
+         # Redirect all processes to the serial console.
          services.journald.extraConfig = ''
            ForwardToConsole=yes
            MaxLevelConsole=debug

--- a/lib/testing.nix
+++ b/lib/testing.nix
@@ -93,11 +93,16 @@ rec {
 
      } // removeAttrs attrs [ "checkPhase" ]);
 
-   # Take a list of derivations and make an attribute set using their name attribute as key
+  # Take a list of derivations and make an attribute set using their name attribute as key
   listDrvToAttrs = list: builtins.listToAttrs (map (attrs: lib.nameValuePair (versionToAttribute attrs.name) attrs) list);
 
-  # Convert dots in the version to dashes
-  # That way the version can be used as attribute key
-  # Example: "blabla-1.2.3" -> "blabla-1-2-3"
+  /* Convert dots in the version to dashes
+     Reasoning: the version can be used as attribute key
+ 
+     Example:
+   
+     "blabla-1.2.3"
+     => "blabla-1-2-3"
+  */
   versionToAttribute = version: builtins.replaceStrings ["."] ["-"] version;
 }

--- a/lib/testing.nix
+++ b/lib/testing.nix
@@ -96,8 +96,18 @@ rec {
   # Take a list of derivations and make an attribute set using their name attribute as key
   listDrvToAttrs = list: builtins.listToAttrs (map (attrs: lib.nameValuePair (versionToAttribute attrs.name) attrs) list);
 
-  /* Convert dots in the version to dashes
-     Reasoning: the version can be used as attribute key
+  /* Merge a list of attributesets. It is assumed keys that collide have the same value.
+  
+     Example:
+ 
+     mergeAttrs [{a = "foo"} {b = "bar"}]
+     => { a = "foo"; b = "bar"; }
+
+  */
+  mergeAttrs = attrs: builtins.foldl' (x: y: x // y) {} attrs;
+
+  /* Convert dots in the version to dashes.
+     Reasoning: the version can be used as attribute key.
  
      Example:
    

--- a/lib/testing.nix
+++ b/lib/testing.nix
@@ -33,7 +33,6 @@ rec {
                 , hardware # on what server group should we run this?
                 , needsNixTestEnv ? false # if true, copies over our test env
                 , testNixEnv ? (mkNixTestEnv {}) # qemu images and kernel
-                , isDPDK ? false # set true if dpdk qemu image is used in the test
                 , alwaysSucceed ? false # if true, the build will succeed even on failure and provide a log
                 , ...
                 }@attrs:
@@ -42,10 +41,7 @@ rec {
 
       buildInputs = [ git telnet tmux numactl bc iproute which qemu utillinux ];
 
-      SNABB_KERNEL_PARAMS = lib.optionalString needsNixTestEnv
-        (if isDPDK
-         then "init=${testNixEnv.snabb_config_dpdk.system.build.toplevel}/init"
-         else "init=${testNixEnv.snabb_config.system.build.toplevel}/init");
+      SNABB_KERNEL_PARAMS = lib.optionalString needsNixTestEnv "init=/nix/var/nix/profiles/system/init";
 
       postUnpack = ''
         patchShebangs .

--- a/lib/testing.nix
+++ b/lib/testing.nix
@@ -3,8 +3,10 @@
 with pkgs;
 
 rec {
+  # Function to build test_env qemu images needed for some benchmarks
   mkNixTestEnv = import ./test_env.nix { pkgs = pkgs; };
 
+  # Default PCCI assignment values for server groups
   PCIAssignments = {
     lugano = {
       SNABB_PCI0 = "0000:01:00.0";
@@ -14,6 +16,8 @@ rec {
     murren = {};
   };
 
+  # Given a server group name such as "lugano"
+  # return attribute set of PCI assignment values
   getPCIVars = hardware:
     let
       pcis = PCIAssignments."${hardware}" or (throw "No such PCIAssignments group as ${hardware}");
@@ -80,6 +84,7 @@ rec {
           set -o pipefail
       '';
 
+      # Adds all files as log types to build products
       installPhase = ''
         runHook preInstall
 
@@ -107,6 +112,8 @@ rec {
    # take a list of derivations and make an attribute set of out their names
   listDrvToAttrs = list: builtins.listToAttrs (map (attrs: lib.nameValuePair (versionToAttribute attrs.name) attrs) list);
 
-  # "blabla-1.2.3" -> "blabla-1-2-3"
+  # Convert dots in the version to dashes
+  # That way the version can be used as attribute key
+  # Example: "blabla-1.2.3" -> "blabla-1-2-3"
   versionToAttribute = version: builtins.replaceStrings ["."] ["-"] version;
 }

--- a/lib/testing.nix
+++ b/lib/testing.nix
@@ -100,11 +100,12 @@ rec {
   
      Example:
  
-     mergeAttrs [{a = "foo"} {b = "bar"}]
+     mergeAttrs [{a = "foo";} {b = "bar";}]
      => { a = "foo"; b = "bar"; }
 
   */
-  mergeAttrs = attrs: builtins.foldl' (x: y: x // y) {} attrs;
+  mergeAttrs = mergeAttrsMap lib.constant;
+  mergeAttrsMap = f: attrs: lib.foldl (x: y: x // (f y)) {} attrs;
 
   /* Convert dots in the version to dashes.
      Reasoning: the version can be used as attribute key.


### PR DESCRIPTION
Tested on https://hydra.snabb.co/jobset/domenkozar-sandbox/pr-72-docs-refactor

- move dpdk/iperf ports configuration inside the benchmark derivation
- move all benchmark meta attributes to `mkSnabbBenchTest`
- merge DPDK and SoftDPDK benchmarks
- move `repeatNum` out of testing.nix (since it doesn't belong there) into `mkSnabbBenchTest`
- add a few doc sentences about functions
- build also `benchmark-csv` on localhost machine to spare time
- remove `isDPDK` parameter with alternative approach so it's not needed anymore
- reduce memory usage in https://github.com/snabblab/snabblab-nixos/pull/72/commits/8e2daac766bc01186438110fcba18545b1a070ab
