### PR TITLE
Benchmark enhancements

### DIFF
--- a/jobsets/snabb-lwaftr.nix
+++ b/jobsets/snabb-lwaftr.nix
@@ -35,6 +35,10 @@
 # Additional dpdk version to benchmark on, specified using source and name
 , qemuAsrc ? null
 , qemuAname ? null
+, duration ? "10"
+, conf ? "icmp_on_fail.conf"
+, ipv4PCap ? "ipv4-0550.pcap"
+, ipv6PCap ? "ipv6-0550.pcap"
 , lwaftrMode 
 }:
 
@@ -62,7 +66,8 @@ let
     else
       locaLib.mergeAttrsMap (qemu:
         locaLib.mergeAttrsMap (snabb:
-          locaLib.selectBenchmarks benchmarkNames { inherit snabb qemu times; mode = lwaftrMode; }
+          locaLib.selectBenchmarks benchmarkNames {
+            inherit snabb qemu times duration conf ipv4PCap ipv6PCap; mode = lwaftrMode; }
         ) snabbs
       ) subQemus;
 

--- a/lib/benchmarks.nix
+++ b/lib/benchmarks.nix
@@ -196,11 +196,11 @@ in rec {
   */
   mkBenchLWAFTR = { snabb
                   , times
-                  , duration ? "10"
-                  , mode ? "bare"
-                  , ipv4PCap ? "ipv4-0550.pcap"
-                  , ipv6PCap ? "ipv6-0550.pcap"
-                  , conf ? "icmp_on_fail.conf"
+                  , duration
+                  , mode
+                  , ipv4PCap
+                  , ipv6PCap
+                  , conf
                   , ... }:
     # TODO: assert mode
     let
@@ -223,7 +223,7 @@ in rec {
           cd src
 
           # Start the application
-          /var/setuid-wrappers/sudo numactl -m 0 taskset -c 1 ${snabb}/bin/snabb lwaftr run \
+          /var/setuid-wrappers/sudo ${snabb}/bin/snabb lwaftr run --cpu=1 \
             --conf program/lwaftr/tests/data/${conf} \
             --v4 0000:$SNABB_PCI0_1 \
             --v6 0000:$SNABB_PCI1_1 \
@@ -231,7 +231,7 @@ in rec {
           RUN_PID=$!
 
           # Generate traffic
-          /var/setuid-wrappers/sudo numactl -m 1 taskset -c 7 ${snabb}/bin/snabb lwaftr loadtest \
+          /var/setuid-wrappers/sudo ${snabb}/bin/snabb lwaftr loadtest --cpu=7 \
             program/lwaftr/tests/benchdata/${ipv4PCap} IPv4 IPv6 0000:$SNABB_PCI0_0 \
             program/lwaftr/tests/benchdata/${ipv6PCap} IPv6 IPv4 0000:$SNABB_PCI1_0 | tee $out/loadtest.log
         '';

--- a/lib/reports/lwaftr.Rmd
+++ b/lib/reports/lwaftr.Rmd
@@ -20,7 +20,7 @@ p <- p + theme(legend.position="top")
 p <- p + geom_point()
 p <- p + geom_line()
 p <- p + expand_limits(y=0)
-p <- p + facet_wrap(~ link, scales="free")
+p <- p + facet_wrap(~link, ncol=2)
 p + ggtitle("Sequential test results")
 ```
 
@@ -29,9 +29,9 @@ p + ggtitle("Sequential test results")
 [Density plot](https://en.wikipedia.org/wiki/Density_estimation) showing the distribution of results. The curve is high around common values and low around rare values. Here we can see how spread out they are, how they cluster together, etc.
 
 ```{r}
-p <- ggplot(lwaftr, aes(score, fill=snabb, color=snabb))
+p <- ggplot(lwaftr, aes(x=score, fill=snabb, color=snabb))
 p <- p + theme(legend.position="top")
 p <- p + geom_density(alpha = 0.1)
-p <- p + facet_wrap(~ link, ncol=1, scales="free")
+p <- p + facet_wrap(~link, ncol=2, scales="free")
 p + ggtitle("Shape (distribution) of test results")
 ```


### PR DESCRIPTION
Expose parameters in `snabb-lwaftr.nix`, moving the default values there.
Update the way of setting the CPU association in commands.
Improve report readability.