### PR TITLE
Add the nic-on-a-stick benchmark, fix the nic one

### DIFF
--- a/lib/benchmarks.nix
+++ b/lib/benchmarks.nix
@@ -231,11 +231,12 @@ in rec {
             --conf program/lwaftr/tests/data/${conf} \
             --v4 0000:$SNABB_PCI0_1 \
             --v6 0000:$SNABB_PCI1_1 \
-            -v -y --bench-file $out/log.csv 2>&1 |tee $out/log.txt&
+            2>&1 | tee $out/log.txt&
           RUN_PID=$!
 
           # Generate traffic
           /var/setuid-wrappers/sudo ${snabb}/bin/snabb lwaftr loadtest --cpu=7 \
+            --hydra --bench-file $out/log.csv \
             program/lwaftr/tests/benchdata/${ipv4PCap} IPv4 IPv6 0000:$SNABB_PCI0_0 \
             program/lwaftr/tests/benchdata/${ipv6PCap} IPv6 IPv4 0000:$SNABB_PCI1_0 | tee $out/loadtest.log
         '';

--- a/lib/benchmarks.nix
+++ b/lib/benchmarks.nix
@@ -210,7 +210,7 @@ in rec {
       hardware = {
         bare = "murren";
         nic = "igalia";
-        nic_packet_loss = "igalia";
+        nic_on_a_stick = "igalia";
         virtualized = "igalia";
       };
       checkPhases = {
@@ -240,14 +240,13 @@ in rec {
             program/lwaftr/tests/benchdata/${ipv6PCap} IPv6 IPv4 0000:$SNABB_PCI1_0 | tee $out/loadtest.log
         '';
         # Two processes, each on their own NUMA node, talking via one NIC card (eventually)
-        nic_packet_loss = ''
+        nic_on_a_stick = ''
           cd src
 
           # Start the application
           /var/setuid-wrappers/sudo ${snabb}/bin/snabb lwaftr run --cpu=1 \
             --conf program/lwaftr/tests/data/${conf} \
-            --v4 0000:$SNABB_PCI0_1 \
-            --v6 0000:$SNABB_PCI1_1 \
+            --on-a-stick 0000:$SNABB_PCI0_1 \
             2>&1 | tee $out/log.txt&
           RUN_PID=$!
 
@@ -255,8 +254,7 @@ in rec {
           /var/setuid-wrappers/sudo ${snabb}/bin/snabb lwaftr loadtest \
             --cpu=7 --bitrate 10e9 --step 1e9 --program ramp_up \
             --hydra --bench-file $out/log.csv \
-            program/lwaftr/tests/benchdata/${ipv4PCap} IPv4 IPv6 0000:$SNABB_PCI0_0 \
-            program/lwaftr/tests/benchdata/${ipv6PCap} IPv6 IPv4 0000:$SNABB_PCI1_0 | tee $out/loadtest.log
+            program/lwaftr/tests/benchdata/${ipv4PCap} ALL ALL 0000:$SNABB_PCI0_0 | tee $out/loadtest.log
         '';
         virtualized = ''
         '';

--- a/lib/benchmarks.nix
+++ b/lib/benchmarks.nix
@@ -238,7 +238,7 @@ in rec {
 
           # Generate traffic
           /var/setuid-wrappers/sudo ${snabb}/bin/snabb lwaftr loadtest --cpu=7 \
-            -s ${loadTestStep} --hydra --bench-file $out/log.csv \
+            --step ${loadTestStep} --hydra --bench-file $out/log.csv \
             program/lwaftr/tests/benchdata/${ipv4PCap} IPv4 IPv6 0000:$SNABB_PCI0_0 \
             program/lwaftr/tests/benchdata/${ipv6PCap} IPv6 IPv4 0000:$SNABB_PCI1_0 | tee $out/loadtest.log
         '';
@@ -254,8 +254,8 @@ in rec {
           RUN_PID=$!
 
           # Generate traffic
-          /var/setuid-wrappers/sudo ${snabb}/bin/snabb lwaftr loadtest \
-            --cpu=7 --bitrate 10e9 --step 1e9 --program ramp_up \
+          /var/setuid-wrappers/sudo ${snabb}/bin/snabb lwaftr loadtest --cpu=7 \
+            --bitrate 10e9 --step ${loadTestStep} --program ramp_up \
             --hydra --bench-file $out/log.csv \
             program/lwaftr/tests/benchdata/${ipv4PCap} ALL ALL 0000:$SNABB_PCI0_0 | tee $out/loadtest.log
         '';

--- a/lib/benchmarks.nix
+++ b/lib/benchmarks.nix
@@ -245,10 +245,10 @@ in rec {
 
           # Generate the traffic files
           /var/setuid-wrappers/sudo ${snabb}/bin/snabb packetblaster lwaftr \
-            --size 64,64,64,64,64,594,594,594,1500 --duration ${duration} \
+            --size 64,64,64,64,64,594,594,594,1500 \
             --rate 10 --count 100000 --pcap ipv4.pcap --v4only
           /var/setuid-wrappers/sudo ${snabb}/bin/snabb packetblaster lwaftr \
-            --size 64,64,64,64,64,594,594,594,1500 --duration ${duration} \
+            --size 64,64,64,64,64,594,594,594,1500 \
             --rate 10 --count 100000 --pcap ipv6.pcap --v6only
 
           # Start the application


### PR DESCRIPTION
Add the `nic-on-a-stick` benchmark. Also change the `nic` benchmark so that `log.csv` is generated by `lwaftr loadtest` rather than by `lwaftr run` (as in `nic-on-a-stick`): this way all benchmark values are available.

Here is an example [output](https://hydra.snabb.co/build/978775/download/2/report.html) of the `nic` benchmark, and [one](https://hydra.snabb.co/build/978394/download/2/report.html) of the `nic-on-a-stick` benchmark.