### PR TITLE
Integrate the snabb-lwaftr-release jobset into the main snabb jobset

### DIFF
--- a/jobsets/snabb.nix
+++ b/jobsets/snabb.nix
@@ -3,6 +3,8 @@
 { pkgs ? (import <nixpkgs> {})
 # which Snabb source directory is used for testing
 , snabbSrc ? (builtins.fetchTarball https://github.com/snabbco/snabb/tarball/next)
+# which lwAftr branch is used
+, lwaftrSrc ? (builtins.fetchTarball https://github.com/Igalia/snabb/tarball/lwaftr)
 # what hardware group is used when executing the jobs
 , hardware ? "lugano"
 }:
@@ -12,6 +14,10 @@ let
 in rec {
   manual = import "${snabbSrc}/src/doc" {};
   snabb = import "${snabbSrc}" {};
+  lwaftr = import "${lwaftrSrc}/tarball.nix" {
+    hydraName = "snabb-lwaftr";
+    src = ${lwaftrSrc};
+  };
   tests = local_lib.mkSnabbTest {
     name = "snabb-tests";
     inherit hardware snabb;


### PR DESCRIPTION
As suggested by @domenkozar a while ago, this moves the currently separate [snabb-lwaftr-release jobset](https://hydra.snabb.co/jobset/igalia/snabb-lwaftr-release) into the [main snabb jobset](https://hydra.snabb.co/jobset/snabb/master).

The latter will need another input with name `lwaftrSrc` and value `https://github.com/igalia/snabb.git lwaftr`.