### PR TITLE
Add dependencies required by guests for IPsec ESP interoperability test

### DIFF
--- a/jobsets/snabb.nix
+++ b/jobsets/snabb.nix
@@ -16,7 +16,7 @@ in rec {
   snabb = import "${snabbSrc}" {};
   lwaftr = import "${lwaftrSrc}/tarball.nix" {
     hydraName = "snabb-lwaftr";
-    src = ${lwaftrSrc};
+    src = "${lwaftrSrc}";
   };
   tests = local_lib.mkSnabbTest {
     name = "snabb-tests";

--- a/lib/test_env.nix
+++ b/lib/test_env.nix
@@ -13,7 +13,7 @@
         <nixpkgs/nixos/modules/profiles/qemu-guest.nix>
         ({config, pkgs, ...}: {
           # Needed tools inside the guest
-          environment.systemPackages = with pkgs; [ inetutils screen python pciutils ethtool tcpdump (hiPrio netcat-openbsd) iperf2 ];
+          environment.systemPackages = with pkgs; [ inetutils screen python pciutils ethtool tcpdump ipsecTools nmap (hiPrio netcat-openbsd) iperf2 ];
 
           fileSystems."/".device = "/dev/disk/by-label/nixos";
           boot.loader.grub.device = "/dev/sda";


### PR DESCRIPTION
- adds ipsecTools and nmap to guest images
- fix a syntax error along the way